### PR TITLE
increase webclient buffer size as we don't stream the response.

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
       max-file-size: 100MB
       max-request-size: 103MB
   codec:
-    max-in-memory-size: 10MB
+    max-in-memory-size: 100MB
 
 backing-services:
   case:


### PR DESCRIPTION
To stream, we just have to use Flux<DataBuffer>, but this means longer connections on the backend services

Signed-off-by: Jon Harper <jon.harper87@gmail.com>