### PR TITLE
Disable reactive elasticsearch client which fails

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -59,6 +59,18 @@ spring:
       enabled: false
       host: localhost
       port: 9200
+  # disable reactive client autoconfiguration because we don't use it and it is
+  # not configured so it tries to connect to localhost which fails. This means
+  # we get an ugly error message at startup, and more importantly that the
+  # health probes fail, so things like k8s think the server is not working and
+  # don't route traffic to it and keep the previous deployment. We have to do
+  # this because the reactiveclient is automatically used by springboot when
+  # starter-webflux is used.
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.actuate.autoconfigure.elasticsearch.ElasticSearchReactiveHealthContributorAutoConfiguration
+      - org.springframework.boot.autoconfigure.data.elasticsearch.ReactiveElasticsearchRepositoriesAutoConfiguration
+      - org.springframework.boot.autoconfigure.data.elasticsearch.ReactiveElasticsearchRestClientAutoConfiguration
 
 backing-services:
   case:


### PR DESCRIPTION
at startup:
reactor.core.Exceptions$ErrorCallbackNotImplemented: org.springframework.data.elasticsearch.client.NoReachableHostException: Host 'localhost:9200' not reachable. Cluster state is offline.
Caused by: org.springframework.data.elasticsearch.client.NoReachableHostException: Host 'localhost:9200' not reachable. Cluster state is offline.
	at org.springframework.data.elasticsearch.client.reactive.SingleNodeHostProvider.lambda$lookupActiveHost$4(SingleNodeHostProvider.java:109) ~[spring-data-elasticsearch-4.1.9.jar:4.1.9]

at every healthcheck:
2021-10-01 08:13:41.037  WARN 1 --- [or-http-epoll-4] a.e.ElasticsearchReactiveHealthIndicator : Elasticsearch health check failed
org.springframework.data.elasticsearch.client.NoReachableHostException: Host 'localhost:9200' not reachable. Cluster state is offline.

Signed-off-by: HARPER Jon <jon.harper87@gmail.com>