### PR TITLE
Elasticsearch client timeout

### DIFF
--- a/src/main/java/org/gridsuite/study/server/elasticsearch/ESConfig.java
+++ b/src/main/java/org/gridsuite/study/server/elasticsearch/ESConfig.java
@@ -44,6 +44,9 @@ public class ESConfig extends AbstractElasticsearchConfiguration {
     @Value("#{'${spring.data.elasticsearch.embedded:false}' ? '${spring.data.elasticsearch.embedded.port:}' : '${spring.data.elasticsearch.port}'}")
     private int esPort;
 
+    @Value("${spring.data.elasticsearch.client.timeout:60}")
+    int timeout;
+
     @Bean
     @ConditionalOnExpression("'${spring.data.elasticsearch.enabled:false}' == 'true'")
     public StudyInfosService studyInfosServiceImpl(StudyInfosRepository studyInfosRepository, ElasticsearchOperations elasticsearchOperations) {
@@ -73,8 +76,9 @@ public class ESConfig extends AbstractElasticsearchConfiguration {
     @SuppressWarnings("squid:S2095")
     public RestHighLevelClient elasticsearchClient() {
         ClientConfiguration clientConfiguration = ClientConfiguration.builder()
-                .connectedTo(InetSocketAddress.createUnresolved(esHost, esPort))
-                .build();
+            .connectedTo(InetSocketAddress.createUnresolved(esHost, esPort))
+            .withConnectTimeout(timeout * 1000L).withSocketTimeout(timeout * 1000L)
+            .build();
 
         return RestClients.create(clientConfiguration).rest();
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -59,6 +59,8 @@ spring:
       enabled: false
       host: localhost
       port: 9200
+      client:
+        timeout: 60  # Seconds
 
 backing-services:
   case:


### PR DESCRIPTION
The timeout of the elasticsearch has 5 seconds as default value.
It's too limited to index a large network and if the indexing fails then the import also fails
`org.springframework.dao.DataAccessResourceFailureException: 5,000 milliseconds timeout on connection http-outgoing-2 [ACTIVE]; nested exception is java.lang.RuntimeException: 5,000 milliseconds timeout on connection http-outgoing-2`
The timeout is now configurable with 60 seconds as default value