### PR TITLE
Fix default model node creation

### DIFF
--- a/src/main/java/org/gridsuite/study/server/networkmodificationtree/ModelNodeInfoRepositoryProxy.java
+++ b/src/main/java/org/gridsuite/study/server/networkmodificationtree/ModelNodeInfoRepositoryProxy.java
@@ -17,6 +17,7 @@ import org.gridsuite.study.server.networkmodificationtree.dto.BuildStatus;
 import org.gridsuite.study.server.networkmodificationtree.entities.ModelNodeInfoEntity;
 import org.gridsuite.study.server.networkmodificationtree.repositories.ModelNodeInfoRepository;
 
+import java.util.Objects;
 import java.util.UUID;
 
 /**
@@ -30,7 +31,9 @@ public class ModelNodeInfoRepositoryProxy extends AbstractNodeRepositoryProxy<Mo
     @Override
     public void createNodeInfo(AbstractNode nodeInfo) {
         ModelNode modelNode = (ModelNode) nodeInfo;
-        modelNode.setBuildStatus(BuildStatus.NOT_BUILT);
+        if (Objects.isNull(modelNode.getBuildStatus())) {
+            modelNode.setBuildStatus(BuildStatus.NOT_BUILT);
+        }
         super.createNodeInfo(modelNode);
     }
 

--- a/src/test/java/org/gridsuite/study/server/NetworkModificationTreeTest.java
+++ b/src/test/java/org/gridsuite/study/server/NetworkModificationTreeTest.java
@@ -207,6 +207,35 @@ public class NetworkModificationTreeTest {
     }
 
     @Test
+    public void testModelNodeCreation() throws Exception {
+        RootNode root = createRoot();
+        // Check build status initialized to NOT_BUILT if null
+        final ModelNode model = buildModel("not_built", "not built node", "loadflow", LoadFlowStatus.NOT_DONE, loadFlowResult, UUID.randomUUID(), null);
+        createNode(root.getStudyId(), root, model);
+        root = getRootNode(root.getStudyId());
+        List<AbstractNode> children = root.getChildren();
+        assertEquals(1, children.size());
+        ModelNode modelNode = (ModelNode) children.get(0);
+        assertEquals(BuildStatus.NOT_BUILT, modelNode.getBuildStatus());
+        assertEquals(LoadFlowStatus.NOT_DONE, modelNode.getLoadFlowStatus());
+        assertEquals("not_built", modelNode.getName());
+        assertEquals("not built node", modelNode.getDescription());
+        deleteNode(root.getStudyId(), children.get(0), false, Set.of(children.get(0)));
+        // Check built status correctly initialized
+        final ModelNode builtModel = buildModel("built", "built node", "loadflow", LoadFlowStatus.CONVERGED, loadFlowResult, UUID.randomUUID(), BuildStatus.BUILT);
+        createNode(root.getStudyId(), root, builtModel);
+        root = getRootNode(root.getStudyId());
+        children = root.getChildren();
+        assertEquals(1, children.size());
+        modelNode = (ModelNode) children.get(0);
+        assertEquals(BuildStatus.BUILT, modelNode.getBuildStatus());
+        assertEquals(LoadFlowStatus.CONVERGED, modelNode.getLoadFlowStatus());
+        assertEquals("built", modelNode.getName());
+        assertEquals("built node", modelNode.getDescription());
+        deleteNode(root.getStudyId(), children.get(0), false, Set.of(children.get(0)));
+    }
+
+    @Test
     public void testNodeManipulation() throws Exception {
         RootNode root = createRoot();
         final NetworkModificationNode hypo = buildNetworkModification("hypo", "potamus", UUID.randomUUID(), "variant_1");


### PR DESCRIPTION
Default model node created when a study is created should have a buildStatus equal to BUILT. 