### PR TITLE
Add @Lazy annotation to avoid initialization when elasticsearch service isn't available at start

### DIFF
--- a/src/main/java/org/gridsuite/study/server/NetworkService.java
+++ b/src/main/java/org/gridsuite/study/server/NetworkService.java
@@ -13,7 +13,9 @@ import com.powsybl.network.store.client.NetworkStoreService;
 import org.gridsuite.study.server.elasticsearch.EquipmentInfosService;
 import org.gridsuite.study.server.repository.StudyEntity;
 import org.gridsuite.study.server.repository.StudyRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
@@ -37,8 +39,9 @@ public class NetworkService {
 
     private final StudyRepository studyRepository;
 
+    @Autowired
     NetworkService(NetworkStoreService networkStoreService,
-                   EquipmentInfosService equipmentInfosService,
+                   @Lazy EquipmentInfosService equipmentInfosService,
                    StudyRepository studyRepository) {
         this.networkStoreService = networkStoreService;
         this.equipmentInfosService = equipmentInfosService;

--- a/src/main/java/org/gridsuite/study/server/NetworkService.java
+++ b/src/main/java/org/gridsuite/study/server/NetworkService.java
@@ -13,7 +13,6 @@ import com.powsybl.network.store.client.NetworkStoreService;
 import org.gridsuite.study.server.elasticsearch.EquipmentInfosService;
 import org.gridsuite.study.server.repository.StudyEntity;
 import org.gridsuite.study.server.repository.StudyRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
@@ -39,7 +38,6 @@ public class NetworkService {
 
     private final StudyRepository studyRepository;
 
-    @Autowired
     NetworkService(NetworkStoreService networkStoreService,
                    @Lazy EquipmentInfosService equipmentInfosService,
                    StudyRepository studyRepository) {

--- a/src/main/java/org/gridsuite/study/server/StudyService.java
+++ b/src/main/java/org/gridsuite/study/server/StudyService.java
@@ -33,6 +33,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.stream.function.StreamBridge;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -199,8 +200,8 @@ public class StudyService {
         NetworkService networkStoreService,
         NetworkModificationService networkModificationService,
         ReportService reportService,
-        StudyInfosService studyInfosService,
-        EquipmentInfosService equipmentInfosService,
+        @Lazy StudyInfosService studyInfosService,
+        @Lazy EquipmentInfosService equipmentInfosService,
         WebClient.Builder webClientBuilder,
         NetworkModificationTreeService networkModificationTreeService,
         ObjectMapper objectMapper) {


### PR DESCRIPTION
ix(NetworkService, StudyService): Add @Lazy annotation to avoid initialization when elasticsearch service isn't available at start.

Signed-off-by: sBouzols <sylvain.bouzols@gmail.com>