### PR TITLE
Add group to study import success consummer, needed when multiple pods

### DIFF
--- a/src/main/resources/config/application.yaml
+++ b/src/main/resources/config/application.yaml
@@ -25,6 +25,9 @@ spring:
           destination: ${powsybl-ws.rabbitmq.destination.prefix:}build.failed
         consumeCaseImportSucceeded-in-0:
           destination: ${powsybl-ws.rabbitmq.destination.prefix:}case.import.succeeded
+          group: importSuccessGroup
+          consumer:
+            concurrency: 1
         consumeCaseImportFailed-in-0:
           destination: ${powsybl-ws.rabbitmq.destination.prefix:}case.import.failed
       source: publishStudyUpdate


### PR DESCRIPTION
For example, we get the following
Caused by: org.postgresql.util.PSQLException: ERROR: duplicate key value violates unique constraint "studyPK"
  Detail: Key (id)=(07538685-7476-4dbd-98e1-52471ee88069) already exists.

because multiple study servers try to insert the study after the case is imported

Signed-off-by: HARPER Jon <jon.harper87@gmail.com>