### PR TITLE
Remove WireMock version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,6 @@
         <equalsverifier-version>3.7.1</equalsverifier-version>
         <testcontainers.version>1.16.2</testcontainers.version>
         <liquibase-hibernate-package>org.gridsuite.study.server</liquibase-hibernate-package>
-        <wiremock.version>2.35.0</wiremock.version>
     </properties>
 
     <build>
@@ -117,12 +116,6 @@
                 <groupId>org.testcontainers</groupId>
                 <artifactId>elasticsearch</artifactId>
                 <version>${testcontainers.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.github.tomakehurst</groupId>
-                <artifactId>wiremock-jre8</artifactId>
-                <version>${wiremock.version}</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
Now included by https://github.com/powsybl/powsybl-ws-dependencies/pull/7

Signed-off-by: Florent MILLOT <millotflo@gmail.com>