### PR TITLE
Swagger API not accept generic type TimeSeries as return type

### DIFF
--- a/src/main/java/org/gridsuite/study/server/RestResponseEntityExceptionHandler.java
+++ b/src/main/java/org/gridsuite/study/server/RestResponseEntityExceptionHandler.java
@@ -67,6 +67,7 @@ public class RestResponseEntityExceptionHandler {
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).body(exception.getMessage());
             case BAD_MODIFICATION_TYPE:
             case BAD_JSON_FORMAT:
+            case TIME_SERIES_ILLEGAL_TYPE:
                 return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exception.getMessage());
             case UNKNOWN_NOTIFICATION_TYPE:
             case UNKNOWN_ACTION_TYPE:

--- a/src/main/java/org/gridsuite/study/server/RestResponseEntityExceptionHandler.java
+++ b/src/main/java/org/gridsuite/study/server/RestResponseEntityExceptionHandler.java
@@ -67,7 +67,7 @@ public class RestResponseEntityExceptionHandler {
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).body(exception.getMessage());
             case BAD_MODIFICATION_TYPE:
             case BAD_JSON_FORMAT:
-            case TIME_SERIES_ILLEGAL_TYPE:
+            case TIME_SERIES_BAD_TYPE:
                 return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exception.getMessage());
             case UNKNOWN_NOTIFICATION_TYPE:
             case UNKNOWN_ACTION_TYPE:

--- a/src/main/java/org/gridsuite/study/server/StudyController.java
+++ b/src/main/java/org/gridsuite/study/server/StudyController.java
@@ -11,7 +11,6 @@ import com.powsybl.loadflow.LoadFlowParameters;
 import com.powsybl.shortcircuit.ShortCircuitParameters;
 import com.powsybl.timeseries.StoredDoubleTimeSeries;
 import com.powsybl.timeseries.StringTimeSeries;
-import com.powsybl.timeseries.TimeSeries;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -1300,14 +1299,7 @@ public class StudyController {
         @ApiResponse(responseCode = "404", description = "The dynamic simulation has not been found")})
     public ResponseEntity<List<StoredDoubleTimeSeries>> getDynamicSimulationTimeSeriesResult(@Parameter(description = "study UUID") @PathVariable("studyUuid") UUID studyUuid,
                                                                      @Parameter(description = "nodeUuid") @PathVariable("nodeUuid") UUID nodeUuid) {
-        List<TimeSeries> timeSeries = studyService.getDynamicSimulationTimeSeries(nodeUuid);
-        // get first element to check type
-        if (timeSeries != null &&
-                !timeSeries.isEmpty() &&
-                !(timeSeries.get(0) instanceof StoredDoubleTimeSeries)) {
-            throw new RuntimeException("Time series can not be a type: " + timeSeries.get(0).getClass().getName());
-        }
-        List<StoredDoubleTimeSeries> result = (List) timeSeries;
+        List<StoredDoubleTimeSeries> result = studyService.getDynamicSimulationTimeSeries(nodeUuid);
         return result != null ? ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(result) :
                 ResponseEntity.noContent().build();
     }
@@ -1319,7 +1311,7 @@ public class StudyController {
         @ApiResponse(responseCode = "404", description = "The dynamic simulation has not been found")})
     public ResponseEntity<List<StringTimeSeries>> getDynamicSimulationTimeLineResult(@Parameter(description = "study UUID") @PathVariable("studyUuid") UUID studyUuid,
                                                                              @Parameter(description = "nodeUuid") @PathVariable("nodeUuid") UUID nodeUuid) {
-        List<StringTimeSeries> result = (List) studyService.getDynamicSimulationTimeLine(nodeUuid);
+        List<StringTimeSeries> result = studyService.getDynamicSimulationTimeLine(nodeUuid);
         return result != null ? ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(result) :
                 ResponseEntity.noContent().build();
     }

--- a/src/main/java/org/gridsuite/study/server/StudyController.java
+++ b/src/main/java/org/gridsuite/study/server/StudyController.java
@@ -9,7 +9,7 @@ package org.gridsuite.study.server;
 import com.powsybl.commons.reporter.ReporterModel;
 import com.powsybl.loadflow.LoadFlowParameters;
 import com.powsybl.shortcircuit.ShortCircuitParameters;
-import com.powsybl.timeseries.StoredDoubleTimeSeries;
+import com.powsybl.timeseries.DoubleTimeSeries;
 import com.powsybl.timeseries.StringTimeSeries;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -1297,9 +1297,9 @@ public class StudyController {
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "All time series of dynamic simulation result"),
         @ApiResponse(responseCode = "204", description = "No dynamic simulation has been done yet"),
         @ApiResponse(responseCode = "404", description = "The dynamic simulation has not been found")})
-    public ResponseEntity<List<StoredDoubleTimeSeries>> getDynamicSimulationTimeSeriesResult(@Parameter(description = "study UUID") @PathVariable("studyUuid") UUID studyUuid,
-                                                                     @Parameter(description = "nodeUuid") @PathVariable("nodeUuid") UUID nodeUuid) {
-        List<StoredDoubleTimeSeries> result = studyService.getDynamicSimulationTimeSeries(nodeUuid);
+    public ResponseEntity<List<DoubleTimeSeries>> getDynamicSimulationTimeSeriesResult(@Parameter(description = "study UUID") @PathVariable("studyUuid") UUID studyUuid,
+                                                                                       @Parameter(description = "nodeUuid") @PathVariable("nodeUuid") UUID nodeUuid) {
+        List<DoubleTimeSeries> result = studyService.getDynamicSimulationTimeSeries(nodeUuid);
         return result != null ? ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(result) :
                 ResponseEntity.noContent().build();
     }

--- a/src/main/java/org/gridsuite/study/server/StudyController.java
+++ b/src/main/java/org/gridsuite/study/server/StudyController.java
@@ -11,6 +11,7 @@ import com.powsybl.loadflow.LoadFlowParameters;
 import com.powsybl.shortcircuit.ShortCircuitParameters;
 import com.powsybl.timeseries.StoredDoubleTimeSeries;
 import com.powsybl.timeseries.StringTimeSeries;
+import com.powsybl.timeseries.TimeSeries;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -1299,7 +1300,14 @@ public class StudyController {
         @ApiResponse(responseCode = "404", description = "The dynamic simulation has not been found")})
     public ResponseEntity<List<StoredDoubleTimeSeries>> getDynamicSimulationTimeSeriesResult(@Parameter(description = "study UUID") @PathVariable("studyUuid") UUID studyUuid,
                                                                      @Parameter(description = "nodeUuid") @PathVariable("nodeUuid") UUID nodeUuid) {
-        List<StoredDoubleTimeSeries> result = (List<StoredDoubleTimeSeries>) (List<?>) studyService.getDynamicSimulationTimeSeries(nodeUuid);
+        List<TimeSeries> timeSeries = studyService.getDynamicSimulationTimeSeries(nodeUuid);
+        // get first element to check type
+        if (timeSeries != null &&
+                !timeSeries.isEmpty() &&
+                !(timeSeries.get(0) instanceof StoredDoubleTimeSeries)) {
+            throw new RuntimeException("Time series can not be a type: " + timeSeries.get(0).getClass().getName());
+        }
+        List<StoredDoubleTimeSeries> result = (List) timeSeries;
         return result != null ? ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(result) :
                 ResponseEntity.noContent().build();
     }
@@ -1311,7 +1319,7 @@ public class StudyController {
         @ApiResponse(responseCode = "404", description = "The dynamic simulation has not been found")})
     public ResponseEntity<List<StringTimeSeries>> getDynamicSimulationTimeLineResult(@Parameter(description = "study UUID") @PathVariable("studyUuid") UUID studyUuid,
                                                                              @Parameter(description = "nodeUuid") @PathVariable("nodeUuid") UUID nodeUuid) {
-        List<StringTimeSeries> result = (List<StringTimeSeries>) (List<?>) studyService.getDynamicSimulationTimeLine(nodeUuid);
+        List<StringTimeSeries> result = (List) studyService.getDynamicSimulationTimeLine(nodeUuid);
         return result != null ? ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(result) :
                 ResponseEntity.noContent().build();
     }

--- a/src/main/java/org/gridsuite/study/server/StudyController.java
+++ b/src/main/java/org/gridsuite/study/server/StudyController.java
@@ -9,7 +9,8 @@ package org.gridsuite.study.server;
 import com.powsybl.commons.reporter.ReporterModel;
 import com.powsybl.loadflow.LoadFlowParameters;
 import com.powsybl.shortcircuit.ShortCircuitParameters;
-import com.powsybl.timeseries.TimeSeries;
+import com.powsybl.timeseries.StoredDoubleTimeSeries;
+import com.powsybl.timeseries.StringTimeSeries;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -1296,9 +1297,9 @@ public class StudyController {
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "All time series of dynamic simulation result"),
         @ApiResponse(responseCode = "204", description = "No dynamic simulation has been done yet"),
         @ApiResponse(responseCode = "404", description = "The dynamic simulation has not been found")})
-    public ResponseEntity<List<TimeSeries>> getDynamicSimulationTimeSeriesResult(@Parameter(description = "study UUID") @PathVariable("studyUuid") UUID studyUuid,
-                                                                       @Parameter(description = "nodeUuid") @PathVariable("nodeUuid") UUID nodeUuid) {
-        List<TimeSeries> result = studyService.getDynamicSimulationTimeSeries(nodeUuid);
+    public ResponseEntity<List<StoredDoubleTimeSeries>> getDynamicSimulationTimeSeriesResult(@Parameter(description = "study UUID") @PathVariable("studyUuid") UUID studyUuid,
+                                                                     @Parameter(description = "nodeUuid") @PathVariable("nodeUuid") UUID nodeUuid) {
+        List<StoredDoubleTimeSeries> result = (List<StoredDoubleTimeSeries>) (List<?>) studyService.getDynamicSimulationTimeSeries(nodeUuid);
         return result != null ? ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(result) :
                 ResponseEntity.noContent().build();
     }
@@ -1308,9 +1309,9 @@ public class StudyController {
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "The timeline of dynamic simulation result"),
         @ApiResponse(responseCode = "204", description = "No dynamic simulation has been done yet"),
         @ApiResponse(responseCode = "404", description = "The dynamic simulation has not been found")})
-    public ResponseEntity<List<TimeSeries>> getDynamicSimulationTimeLineResult(@Parameter(description = "study UUID") @PathVariable("studyUuid") UUID studyUuid,
-                                                                               @Parameter(description = "nodeUuid") @PathVariable("nodeUuid") UUID nodeUuid) {
-        List<TimeSeries> result = studyService.getDynamicSimulationTimeLine(nodeUuid);
+    public ResponseEntity<List<StringTimeSeries>> getDynamicSimulationTimeLineResult(@Parameter(description = "study UUID") @PathVariable("studyUuid") UUID studyUuid,
+                                                                             @Parameter(description = "nodeUuid") @PathVariable("nodeUuid") UUID nodeUuid) {
+        List<StringTimeSeries> result = (List<StringTimeSeries>) (List<?>) studyService.getDynamicSimulationTimeLine(nodeUuid);
         return result != null ? ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(result) :
                 ResponseEntity.noContent().build();
     }

--- a/src/main/java/org/gridsuite/study/server/StudyException.java
+++ b/src/main/java/org/gridsuite/study/server/StudyException.java
@@ -61,6 +61,7 @@ public class StudyException extends RuntimeException {
         DELETE_ATTACHING_LINE,
         GENERATOR_SCALING_FAILED,
         URI_SYNTAX,
+        TIME_SERIES_ILLEGAL_TYPE,
     }
 
     private final Type type;

--- a/src/main/java/org/gridsuite/study/server/StudyException.java
+++ b/src/main/java/org/gridsuite/study/server/StudyException.java
@@ -61,7 +61,7 @@ public class StudyException extends RuntimeException {
         DELETE_ATTACHING_LINE,
         GENERATOR_SCALING_FAILED,
         URI_SYNTAX,
-        TIME_SERIES_ILLEGAL_TYPE,
+        TIME_SERIES_BAD_TYPE,
     }
 
     private final Type type;

--- a/src/main/java/org/gridsuite/study/server/service/StudyService.java
+++ b/src/main/java/org/gridsuite/study/server/service/StudyService.java
@@ -17,7 +17,7 @@ import com.powsybl.network.store.model.VariantInfos;
 import com.powsybl.security.SecurityAnalysisParameters;
 import com.powsybl.sensitivity.SensitivityAnalysisParameters;
 import com.powsybl.shortcircuit.ShortCircuitParameters;
-import com.powsybl.timeseries.StoredDoubleTimeSeries;
+import com.powsybl.timeseries.DoubleTimeSeries;
 import com.powsybl.timeseries.StringTimeSeries;
 import lombok.NonNull;
 import org.apache.commons.lang3.StringUtils;
@@ -1628,7 +1628,7 @@ public class StudyService {
         return resultUuid;
     }
 
-    public List<StoredDoubleTimeSeries> getDynamicSimulationTimeSeries(UUID nodeUuid) {
+    public List<DoubleTimeSeries> getDynamicSimulationTimeSeries(UUID nodeUuid) {
         // get timeseries from node uuid
         return dynamicSimulationService.getTimeSeriesResult(nodeUuid);
     }

--- a/src/main/java/org/gridsuite/study/server/service/StudyService.java
+++ b/src/main/java/org/gridsuite/study/server/service/StudyService.java
@@ -17,7 +17,8 @@ import com.powsybl.network.store.model.VariantInfos;
 import com.powsybl.security.SecurityAnalysisParameters;
 import com.powsybl.sensitivity.SensitivityAnalysisParameters;
 import com.powsybl.shortcircuit.ShortCircuitParameters;
-import com.powsybl.timeseries.TimeSeries;
+import com.powsybl.timeseries.StoredDoubleTimeSeries;
+import com.powsybl.timeseries.StringTimeSeries;
 import lombok.NonNull;
 import org.apache.commons.lang3.StringUtils;
 import org.elasticsearch.index.query.BoolQueryBuilder;
@@ -1627,12 +1628,12 @@ public class StudyService {
         return resultUuid;
     }
 
-    public List<TimeSeries> getDynamicSimulationTimeSeries(UUID nodeUuid) {
+    public List<StoredDoubleTimeSeries> getDynamicSimulationTimeSeries(UUID nodeUuid) {
         // get timeseries from node uuid
         return dynamicSimulationService.getTimeSeriesResult(nodeUuid);
     }
 
-    public List<TimeSeries> getDynamicSimulationTimeLine(UUID nodeUuid) {
+    public List<StringTimeSeries> getDynamicSimulationTimeLine(UUID nodeUuid) {
         // get timeline from node uuid
         return dynamicSimulationService.getTimeLineResult(nodeUuid); // timeline has only one element
     }

--- a/src/main/java/org/gridsuite/study/server/service/dynamicsimulation/DynamicSimulationService.java
+++ b/src/main/java/org/gridsuite/study/server/service/dynamicsimulation/DynamicSimulationService.java
@@ -7,7 +7,7 @@
 
 package org.gridsuite.study.server.service.dynamicsimulation;
 
-import com.powsybl.timeseries.StoredDoubleTimeSeries;
+import com.powsybl.timeseries.DoubleTimeSeries;
 import com.powsybl.timeseries.StringTimeSeries;
 import org.gridsuite.study.server.dto.dynamicmapping.MappingInfos;
 import org.gridsuite.study.server.dto.dynamicsimulation.DynamicSimulationStatus;
@@ -36,7 +36,7 @@ public interface DynamicSimulationService {
      * @param nodeUuid a given node UUID
      * @return a list of curves
      */
-    List<StoredDoubleTimeSeries> getTimeSeriesResult(UUID nodeUuid);
+    List<DoubleTimeSeries> getTimeSeriesResult(UUID nodeUuid);
 
     /**
      * Get timeline from a given node UUID

--- a/src/main/java/org/gridsuite/study/server/service/dynamicsimulation/DynamicSimulationService.java
+++ b/src/main/java/org/gridsuite/study/server/service/dynamicsimulation/DynamicSimulationService.java
@@ -7,7 +7,8 @@
 
 package org.gridsuite.study.server.service.dynamicsimulation;
 
-import com.powsybl.timeseries.TimeSeries;
+import com.powsybl.timeseries.StoredDoubleTimeSeries;
+import com.powsybl.timeseries.StringTimeSeries;
 import org.gridsuite.study.server.dto.dynamicmapping.MappingInfos;
 import org.gridsuite.study.server.dto.dynamicsimulation.DynamicSimulationStatus;
 
@@ -35,7 +36,7 @@ public interface DynamicSimulationService {
      * @param nodeUuid a given node UUID
      * @return a list of curves
      */
-    List<TimeSeries> getTimeSeriesResult(UUID nodeUuid);
+    List<StoredDoubleTimeSeries> getTimeSeriesResult(UUID nodeUuid);
 
     /**
      * Get timeline from a given node UUID
@@ -43,7 +44,7 @@ public interface DynamicSimulationService {
      * @param nodeUuid a given node UUID
      * @return a list of timeline (only one element)
      */
-    List<TimeSeries> getTimeLineResult(UUID nodeUuid);
+    List<StringTimeSeries> getTimeLineResult(UUID nodeUuid);
 
     /**
      * Get the current status of the simulation

--- a/src/main/java/org/gridsuite/study/server/service/dynamicsimulation/impl/DynamicSimulationServiceImpl.java
+++ b/src/main/java/org/gridsuite/study/server/service/dynamicsimulation/impl/DynamicSimulationServiceImpl.java
@@ -7,7 +7,7 @@
 
 package org.gridsuite.study.server.service.dynamicsimulation.impl;
 
-import com.powsybl.timeseries.StoredDoubleTimeSeries;
+import com.powsybl.timeseries.DoubleTimeSeries;
 import com.powsybl.timeseries.StringTimeSeries;
 import com.powsybl.timeseries.TimeSeries;
 import org.gridsuite.study.server.StudyException;
@@ -54,7 +54,7 @@ public class DynamicSimulationServiceImpl implements DynamicSimulationService {
     }
 
     @Override
-    public List<StoredDoubleTimeSeries> getTimeSeriesResult(UUID nodeUuid) {
+    public List<DoubleTimeSeries> getTimeSeriesResult(UUID nodeUuid) {
         Optional<UUID> resultUuidOpt = networkModificationTreeService.getDynamicSimulationResultUuid(nodeUuid);
 
         if (resultUuidOpt.isEmpty()) {
@@ -68,8 +68,9 @@ public class DynamicSimulationServiceImpl implements DynamicSimulationService {
         // get first element to check type
         if (timeSeries != null &&
                 !timeSeries.isEmpty() &&
-                !(timeSeries.get(0) instanceof StoredDoubleTimeSeries)) {
-            throw new StudyException(StudyException.Type.TIME_SERIES_BAD_TYPE, "Time series can not be a type: " + timeSeries.get(0).getClass().getSimpleName());
+                !(timeSeries.get(0) instanceof DoubleTimeSeries)) {
+            throw new StudyException(StudyException.Type.TIME_SERIES_BAD_TYPE, "Time series can not be a type: " + timeSeries.get(0).getClass().getSimpleName()
+                    + ", expected type: " + DoubleTimeSeries.class.getSimpleName());
         }
 
         return (List) timeSeries;
@@ -91,7 +92,8 @@ public class DynamicSimulationServiceImpl implements DynamicSimulationService {
         if (timeLines != null &&
                 !timeLines.isEmpty() &&
                 !(timeLines.get(0) instanceof StringTimeSeries)) {
-            throw new StudyException(StudyException.Type.TIME_SERIES_BAD_TYPE, "Time lines can not be a type: " + timeLines.get(0).getClass().getSimpleName());
+            throw new StudyException(StudyException.Type.TIME_SERIES_BAD_TYPE, "Time lines can not be a type: " + timeLines.get(0).getClass().getSimpleName()
+                    + ", expected type: " + StringTimeSeries.class.getSimpleName());
         }
 
         return (List) timeLines;

--- a/src/main/java/org/gridsuite/study/server/service/dynamicsimulation/impl/DynamicSimulationServiceImpl.java
+++ b/src/main/java/org/gridsuite/study/server/service/dynamicsimulation/impl/DynamicSimulationServiceImpl.java
@@ -69,7 +69,7 @@ public class DynamicSimulationServiceImpl implements DynamicSimulationService {
         if (timeSeries != null &&
                 !timeSeries.isEmpty() &&
                 !(timeSeries.get(0) instanceof StoredDoubleTimeSeries)) {
-            throw new StudyException(StudyException.Type.TIME_SERIES_ILLEGAL_TYPE, "Time series can not be a type: " + timeSeries.get(0).getClass().getSimpleName());
+            throw new StudyException(StudyException.Type.TIME_SERIES_BAD_TYPE, "Time series can not be a type: " + timeSeries.get(0).getClass().getSimpleName());
         }
 
         return (List) timeSeries;
@@ -91,7 +91,7 @@ public class DynamicSimulationServiceImpl implements DynamicSimulationService {
         if (timeLines != null &&
                 !timeLines.isEmpty() &&
                 !(timeLines.get(0) instanceof StringTimeSeries)) {
-            throw new StudyException(StudyException.Type.TIME_SERIES_ILLEGAL_TYPE, "Time lines can not be a type: " + timeLines.get(0).getClass().getSimpleName());
+            throw new StudyException(StudyException.Type.TIME_SERIES_BAD_TYPE, "Time lines can not be a type: " + timeLines.get(0).getClass().getSimpleName());
         }
 
         return (List) timeLines;

--- a/src/main/java/org/gridsuite/study/server/service/dynamicsimulation/impl/DynamicSimulationServiceImpl.java
+++ b/src/main/java/org/gridsuite/study/server/service/dynamicsimulation/impl/DynamicSimulationServiceImpl.java
@@ -7,6 +7,8 @@
 
 package org.gridsuite.study.server.service.dynamicsimulation.impl;
 
+import com.powsybl.timeseries.StoredDoubleTimeSeries;
+import com.powsybl.timeseries.StringTimeSeries;
 import com.powsybl.timeseries.TimeSeries;
 import org.gridsuite.study.server.StudyException;
 import org.gridsuite.study.server.dto.dynamicmapping.MappingInfos;
@@ -52,25 +54,47 @@ public class DynamicSimulationServiceImpl implements DynamicSimulationService {
     }
 
     @Override
-    public List<TimeSeries> getTimeSeriesResult(UUID nodeUuid) {
+    public List<StoredDoubleTimeSeries> getTimeSeriesResult(UUID nodeUuid) {
         Optional<UUID> resultUuidOpt = networkModificationTreeService.getDynamicSimulationResultUuid(nodeUuid);
 
         if (resultUuidOpt.isEmpty()) {
             return Collections.emptyList();
         }
         UUID timeSeriesUuid = dynamicSimulationClient.getTimeSeriesResult(resultUuidOpt.get()); // get timeseries uuid
-        return timeSeriesClient.getTimeSeriesGroup(timeSeriesUuid); // get timeseries data
+
+        // get timeseries data
+        List<TimeSeries> timeSeries = timeSeriesClient.getTimeSeriesGroup(timeSeriesUuid);
+
+        // get first element to check type
+        if (timeSeries != null &&
+                !timeSeries.isEmpty() &&
+                !(timeSeries.get(0) instanceof StoredDoubleTimeSeries)) {
+            throw new StudyException(StudyException.Type.TIME_SERIES_ILLEGAL_TYPE, "Time series can not be a type: " + timeSeries.get(0).getClass().getSimpleName());
+        }
+
+        return (List) timeSeries;
     }
 
     @Override
-    public List<TimeSeries> getTimeLineResult(UUID nodeUuid) {
+    public List<StringTimeSeries> getTimeLineResult(UUID nodeUuid) {
         Optional<UUID> resultUuidOpt = networkModificationTreeService.getDynamicSimulationResultUuid(nodeUuid);
 
         if (resultUuidOpt.isEmpty()) {
             return Collections.emptyList();
         }
         UUID timeLineUuid = dynamicSimulationClient.getTimeLineResult(resultUuidOpt.get()); // get timeline uuid
-        return timeSeriesClient.getTimeSeriesGroup(timeLineUuid); // get timeline data
+
+        // get timeline data
+        List<TimeSeries> timeLines = timeSeriesClient.getTimeSeriesGroup(timeLineUuid);
+
+        // get first element to check type
+        if (timeLines != null &&
+                !timeLines.isEmpty() &&
+                !(timeLines.get(0) instanceof StringTimeSeries)) {
+            throw new StudyException(StudyException.Type.TIME_SERIES_ILLEGAL_TYPE, "Time lines can not be a type: " + timeLines.get(0).getClass().getSimpleName());
+        }
+
+        return (List) timeLines;
     }
 
     @Override

--- a/src/test/java/org/gridsuite/study/server/StudyControllerDynamicSimulationTest.java
+++ b/src/test/java/org/gridsuite/study/server/StudyControllerDynamicSimulationTest.java
@@ -331,7 +331,7 @@ public class StudyControllerDynamicSimulationTest {
     public void testGetDynamicSimulationTimeSeriesResult() throws Exception {
         // timeseries
         TimeSeriesIndex index = new IrregularTimeSeriesIndex(new long[]{32, 64, 128, 256});
-        List<StoredDoubleTimeSeries> timeSeries = new ArrayList<>(Arrays.asList(
+        List<DoubleTimeSeries> timeSeries = new ArrayList<>(Arrays.asList(
                 TimeSeries.createDouble("NETWORK__BUS____2-BUS____5-1_AC_iSide2", index, 333.847331, 333.847321, 333.847300, 333.847259),
                 TimeSeries.createDouble("NETWORK__BUS____1_TN_Upu_value", index, 1.059970, 1.059970, 1.059970, 1.059970)
         ));

--- a/src/test/java/org/gridsuite/study/server/StudyControllerDynamicSimulationTest.java
+++ b/src/test/java/org/gridsuite/study/server/StudyControllerDynamicSimulationTest.java
@@ -9,10 +9,7 @@ package org.gridsuite.study.server;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.powsybl.timeseries.IrregularTimeSeriesIndex;
-import com.powsybl.timeseries.StringTimeSeries;
-import com.powsybl.timeseries.TimeSeries;
-import com.powsybl.timeseries.TimeSeriesIndex;
+import com.powsybl.timeseries.*;
 import org.apache.logging.log4j.util.Strings;
 import org.gridsuite.study.server.dto.NodeReceiver;
 import org.gridsuite.study.server.dto.dynamicmapping.MappingInfos;
@@ -334,7 +331,7 @@ public class StudyControllerDynamicSimulationTest {
     public void testGetDynamicSimulationTimeSeriesResult() throws Exception {
         // timeseries
         TimeSeriesIndex index = new IrregularTimeSeriesIndex(new long[]{32, 64, 128, 256});
-        List<TimeSeries> timeSeries = new ArrayList<>(Arrays.asList(
+        List<StoredDoubleTimeSeries> timeSeries = new ArrayList<>(Arrays.asList(
                 TimeSeries.createDouble("NETWORK__BUS____2-BUS____5-1_AC_iSide2", index, 333.847331, 333.847321, 333.847300, 333.847259),
                 TimeSeries.createDouble("NETWORK__BUS____1_TN_Upu_value", index, 1.059970, 1.059970, 1.059970, 1.059970)
         ));

--- a/src/test/java/org/gridsuite/study/server/service/StudyServiceDynamicSimulationTest.java
+++ b/src/test/java/org/gridsuite/study/server/service/StudyServiceDynamicSimulationTest.java
@@ -9,10 +9,7 @@ package org.gridsuite.study.server.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.powsybl.timeseries.IrregularTimeSeriesIndex;
-import com.powsybl.timeseries.StringTimeSeries;
-import com.powsybl.timeseries.TimeSeries;
-import com.powsybl.timeseries.TimeSeriesIndex;
+import com.powsybl.timeseries.*;
 import org.gridsuite.study.server.StudyApplication;
 import org.gridsuite.study.server.dto.LoadFlowStatus;
 import org.gridsuite.study.server.dto.dynamicmapping.MappingInfos;
@@ -138,7 +135,7 @@ public class StudyServiceDynamicSimulationTest {
         // setup
         // timeseries
         TimeSeriesIndex index = new IrregularTimeSeriesIndex(new long[]{32, 64, 128, 256});
-        List<TimeSeries> timeSeries = new ArrayList<>(Arrays.asList(
+        List<StoredDoubleTimeSeries> timeSeries = new ArrayList<>(Arrays.asList(
                 TimeSeries.createDouble("NETWORK__BUS____2-BUS____5-1_AC_iSide2", index, 333.847331, 333.847321, 333.847300, 333.847259),
                 TimeSeries.createDouble("NETWORK__BUS____1_TN_Upu_value", index, 1.059970, 1.059970, 1.059970, 1.059970)
         ));

--- a/src/test/java/org/gridsuite/study/server/service/StudyServiceDynamicSimulationTest.java
+++ b/src/test/java/org/gridsuite/study/server/service/StudyServiceDynamicSimulationTest.java
@@ -135,7 +135,7 @@ public class StudyServiceDynamicSimulationTest {
         // setup
         // timeseries
         TimeSeriesIndex index = new IrregularTimeSeriesIndex(new long[]{32, 64, 128, 256});
-        List<StoredDoubleTimeSeries> timeSeries = new ArrayList<>(Arrays.asList(
+        List<DoubleTimeSeries> timeSeries = new ArrayList<>(Arrays.asList(
                 TimeSeries.createDouble("NETWORK__BUS____2-BUS____5-1_AC_iSide2", index, 333.847331, 333.847321, 333.847300, 333.847259),
                 TimeSeries.createDouble("NETWORK__BUS____1_TN_Upu_value", index, 1.059970, 1.059970, 1.059970, 1.059970)
         ));

--- a/src/test/java/org/gridsuite/study/server/service/dynamicsimulation/DynamicSimulationServiceTest.java
+++ b/src/test/java/org/gridsuite/study/server/service/dynamicsimulation/DynamicSimulationServiceTest.java
@@ -134,6 +134,25 @@ public class DynamicSimulationServiceTest {
         assertEquals(2, timeSeriesResult.size());
     }
 
+    @Test(expected = StudyException.class)
+    public void testGetTimeSeriesResultGivenBadType() {
+        // setup DynamicSimulationClient mock
+        given(dynamicSimulationClient.getTimeSeriesResult(RESULT_UUID)).willReturn(TIME_SERIES_UUID);
+
+        // setup timeSeriesClient mock
+        // create a bad type timeseries
+        TimeSeriesIndex index = new IrregularTimeSeriesIndex(new long[]{102479, 102479, 102479, 104396});
+        List<TimeSeries> timeSeries = List.of(TimeSeries.createString("TimeLine", index,
+                "CLA_2_5 - CLA : order to change topology",
+                "_BUS____2-BUS____5-1_AC - LINE : opening both sides",
+                "CLA_2_5 - CLA : order to change topology",
+                "CLA_2_4 - CLA : arming by over-current constraint"));
+        given(timeSeriesClient.getTimeSeriesGroup(TIME_SERIES_UUID)).willReturn(timeSeries);
+
+        // call method to be tested
+        dynamicSimulationService.getTimeSeriesResult(NODE_UUID);
+    }
+
     @Test
     public void testGetTimeLineResult() {
         // setup DynamicSimulationClient mock
@@ -155,6 +174,22 @@ public class DynamicSimulationServiceTest {
         // check result
         // must contain only one
         assertEquals(1, timeLineResult.size());
+    }
+
+    @Test(expected = StudyException.class)
+    public void testGetTimeLineResultGivenBadType() {
+        // setup DynamicSimulationClient mock
+        given(dynamicSimulationClient.getTimeLineResult(RESULT_UUID)).willReturn(TIME_LINE_UUID);
+
+        // setup timeSeriesClient mock
+        // create a bad type timeline
+        TimeSeriesIndex index = new IrregularTimeSeriesIndex(new long[]{102479, 102479, 102479, 104396});
+        List<TimeSeries> timeLines = List.of(TimeSeries.createDouble("NETWORK__BUS____2-BUS____5-1_AC_iSide2", index, 333.847331, 333.847321, 333.847300, 333.847259));
+
+        given(timeSeriesClient.getTimeSeriesGroup(TIME_LINE_UUID)).willReturn(timeLines);
+
+        // call method to be tested
+        dynamicSimulationService.getTimeLineResult(NODE_UUID);
     }
 
     @Test

--- a/src/test/java/org/gridsuite/study/server/service/dynamicsimulation/DynamicSimulationServiceTest.java
+++ b/src/test/java/org/gridsuite/study/server/service/dynamicsimulation/DynamicSimulationServiceTest.java
@@ -7,10 +7,7 @@
 
 package org.gridsuite.study.server.service.dynamicsimulation;
 
-import com.powsybl.timeseries.IrregularTimeSeriesIndex;
-import com.powsybl.timeseries.StringTimeSeries;
-import com.powsybl.timeseries.TimeSeries;
-import com.powsybl.timeseries.TimeSeriesIndex;
+import com.powsybl.timeseries.*;
 import org.gridsuite.study.server.StudyApplication;
 import org.gridsuite.study.server.StudyException;
 import org.gridsuite.study.server.dto.dynamicmapping.MappingInfos;
@@ -130,7 +127,7 @@ public class DynamicSimulationServiceTest {
         given(timeSeriesClient.getTimeSeriesGroup(TIME_SERIES_UUID)).willReturn(timeSeries);
 
         // call method to be tested
-        List<TimeSeries> timeSeriesResult = dynamicSimulationService.getTimeSeriesResult(NODE_UUID);
+        List<StoredDoubleTimeSeries> timeSeriesResult = dynamicSimulationService.getTimeSeriesResult(NODE_UUID);
 
         // check result
         // must contain two elements
@@ -153,7 +150,7 @@ public class DynamicSimulationServiceTest {
         given(timeSeriesClient.getTimeSeriesGroup(TIME_LINE_UUID)).willReturn(Arrays.asList(timeLine));
 
         // call method to be tested
-        List<TimeSeries> timeLineResult = dynamicSimulationService.getTimeLineResult(NODE_UUID);
+        List<StringTimeSeries> timeLineResult = dynamicSimulationService.getTimeLineResult(NODE_UUID);
 
         // check result
         // must contain only one

--- a/src/test/java/org/gridsuite/study/server/service/dynamicsimulation/DynamicSimulationServiceTest.java
+++ b/src/test/java/org/gridsuite/study/server/service/dynamicsimulation/DynamicSimulationServiceTest.java
@@ -127,7 +127,7 @@ public class DynamicSimulationServiceTest {
         given(timeSeriesClient.getTimeSeriesGroup(TIME_SERIES_UUID)).willReturn(timeSeries);
 
         // call method to be tested
-        List<StoredDoubleTimeSeries> timeSeriesResult = dynamicSimulationService.getTimeSeriesResult(NODE_UUID);
+        List<DoubleTimeSeries> timeSeriesResult = dynamicSimulationService.getTimeSeriesResult(NODE_UUID);
 
         // check result
         // must contain two elements


### PR DESCRIPTION
Cause: in my opinion, the loop infinite is from the definition of type TimeSeries in recursive manner!
`TimeSeries<P extends AbstractPoint, T extends TimeSeries<P, T>>`

 
Solution: 
- Return with a parameterized type DoubleTimeSeries for timeseries and StringTimeSeries for timeline 
- Check type a service level, if KO throw an exception 