### PR TITLE
Dynamic simulation - use dynamic port for mock web server in unit tests

### DIFF
--- a/src/test/java/org/gridsuite/study/server/service/client/AbstractRestClientTest.java
+++ b/src/test/java/org/gridsuite/study/server/service/client/AbstractRestClientTest.java
@@ -32,6 +32,8 @@ import java.io.IOException;
 @ContextHierarchy({@ContextConfiguration(classes = {StudyApplication.class, TestChannelBinderConfiguration.class})})
 public abstract class AbstractRestClientTest {
 
+    protected static final int DYNAMIC_PORT = 0;
+
     protected MockWebServer server;
 
     public final Logger getLogger() {
@@ -43,7 +45,13 @@ public abstract class AbstractRestClientTest {
     protected String initMockWebServer(int port) throws RuntimeException {
         server = new MockWebServer();
         try {
-            server.start(port);
+            if (port == DYNAMIC_PORT) {
+                server.start();
+            } else {
+                server.start(port);
+            }
+
+            getLogger().info("Mock server started at port = " + server.getPort());
         } catch (IOException e) {
             throw new RuntimeException("Can not init the mock server " + this.getClass().getSimpleName(), e);
         }

--- a/src/test/java/org/gridsuite/study/server/service/client/AbstractRestClientTest.java
+++ b/src/test/java/org/gridsuite/study/server/service/client/AbstractRestClientTest.java
@@ -32,8 +32,6 @@ import java.io.IOException;
 @ContextHierarchy({@ContextConfiguration(classes = {StudyApplication.class, TestChannelBinderConfiguration.class})})
 public abstract class AbstractRestClientTest {
 
-    protected static final int DYNAMIC_PORT = 0;
-
     protected MockWebServer server;
 
     public final Logger getLogger() {
@@ -42,15 +40,10 @@ public abstract class AbstractRestClientTest {
 
     protected abstract Dispatcher getDispatcher();
 
-    protected String initMockWebServer(int port) throws RuntimeException {
+    protected String initMockWebServer() throws RuntimeException {
         server = new MockWebServer();
         try {
-            if (port == DYNAMIC_PORT) {
-                server.start();
-            } else {
-                server.start(port);
-            }
-
+            server.start();
             getLogger().info("Mock server started at port = " + server.getPort());
         } catch (IOException e) {
             throw new RuntimeException("Can not init the mock server " + this.getClass().getSimpleName(), e);

--- a/src/test/java/org/gridsuite/study/server/service/client/dynamicmapping/DynamicMappingClientTest.java
+++ b/src/test/java/org/gridsuite/study/server/service/client/dynamicmapping/DynamicMappingClientTest.java
@@ -38,7 +38,7 @@ public class DynamicMappingClientTest extends AbstractRestClientTest {
     private static final List<MappingInfos> MAPPINGS = Arrays.asList(new MappingInfos(MAPPING_NAMES[0]),
                                                         new MappingInfos(MAPPING_NAMES[1]));
 
-    private static final int DYNAMIC_MAPPING_PORT = 5036;
+    private static final int DYNAMIC_MAPPING_PORT = DYNAMIC_PORT;
 
     private DynamicMappingClient dynamicMappingClient;
 

--- a/src/test/java/org/gridsuite/study/server/service/client/dynamicmapping/DynamicMappingClientTest.java
+++ b/src/test/java/org/gridsuite/study/server/service/client/dynamicmapping/DynamicMappingClientTest.java
@@ -38,8 +38,6 @@ public class DynamicMappingClientTest extends AbstractRestClientTest {
     private static final List<MappingInfos> MAPPINGS = Arrays.asList(new MappingInfos(MAPPING_NAMES[0]),
                                                         new MappingInfos(MAPPING_NAMES[1]));
 
-    private static final int DYNAMIC_MAPPING_PORT = DYNAMIC_PORT;
-
     private DynamicMappingClient dynamicMappingClient;
 
     @Autowired
@@ -84,7 +82,7 @@ public class DynamicMappingClientTest extends AbstractRestClientTest {
         super.setup();
 
         // config client
-        dynamicMappingClient = new DynamicMappingClientImpl(initMockWebServer(DYNAMIC_MAPPING_PORT), restTemplate);
+        dynamicMappingClient = new DynamicMappingClientImpl(initMockWebServer(), restTemplate);
     }
 
     @Test

--- a/src/test/java/org/gridsuite/study/server/service/client/dynamicsimulation/DynamicSimulationClientTest.java
+++ b/src/test/java/org/gridsuite/study/server/service/client/dynamicsimulation/DynamicSimulationClientTest.java
@@ -35,7 +35,7 @@ import static org.junit.Assert.assertTrue;
  */
 public class DynamicSimulationClientTest extends AbstractRestClientTest {
 
-    private static final int DYNAMIC_SIMULATION_PORT = 5032;
+    private static final int DYNAMIC_SIMULATION_PORT = DYNAMIC_PORT;
 
     private static final String NETWORK_UUID_STRING = "11111111-0000-0000-0000-000000000000";
 

--- a/src/test/java/org/gridsuite/study/server/service/client/dynamicsimulation/DynamicSimulationClientTest.java
+++ b/src/test/java/org/gridsuite/study/server/service/client/dynamicsimulation/DynamicSimulationClientTest.java
@@ -35,8 +35,6 @@ import static org.junit.Assert.assertTrue;
  */
 public class DynamicSimulationClientTest extends AbstractRestClientTest {
 
-    private static final int DYNAMIC_SIMULATION_PORT = DYNAMIC_PORT;
-
     private static final String NETWORK_UUID_STRING = "11111111-0000-0000-0000-000000000000";
 
     private static final String VARIANT_1_ID = "variant_1";
@@ -153,7 +151,7 @@ public class DynamicSimulationClientTest extends AbstractRestClientTest {
         super.setup();
 
         // config client
-        dynamicSimulationClient = new DynamicSimulationClientImpl(initMockWebServer(DYNAMIC_SIMULATION_PORT), restTemplate);
+        dynamicSimulationClient = new DynamicSimulationClientImpl(initMockWebServer(), restTemplate);
     }
 
     @Test

--- a/src/test/java/org/gridsuite/study/server/service/client/timeseries/TimeSeriesClientTest.java
+++ b/src/test/java/org/gridsuite/study/server/service/client/timeseries/TimeSeriesClientTest.java
@@ -37,7 +37,7 @@ import static org.junit.Assert.assertEquals;
  */
 public class TimeSeriesClientTest extends AbstractRestClientTest {
 
-    private static final int TIME_SERIES_PORT = 5037;
+    private static final int TIME_SERIES_PORT = DYNAMIC_PORT;
     public static final String TIME_SERIES_GROUP_UUID = "33333333-0000-0000-0000-000000000000";
     public static final String TIME_LINE_GROUP_UUID = "44444444-0000-0000-0000-000000000000";
 

--- a/src/test/java/org/gridsuite/study/server/service/client/timeseries/TimeSeriesClientTest.java
+++ b/src/test/java/org/gridsuite/study/server/service/client/timeseries/TimeSeriesClientTest.java
@@ -37,7 +37,6 @@ import static org.junit.Assert.assertEquals;
  */
 public class TimeSeriesClientTest extends AbstractRestClientTest {
 
-    private static final int TIME_SERIES_PORT = DYNAMIC_PORT;
     public static final String TIME_SERIES_GROUP_UUID = "33333333-0000-0000-0000-000000000000";
     public static final String TIME_LINE_GROUP_UUID = "44444444-0000-0000-0000-000000000000";
 
@@ -108,7 +107,7 @@ public class TimeSeriesClientTest extends AbstractRestClientTest {
         database.put(TIME_LINE_GROUP_UUID, new ArrayList<>(Arrays.asList(timeLine)));
 
         // config client
-        timeSeriesClient = new TimeSeriesClientImpl(initMockWebServer(TIME_SERIES_PORT), restTemplate);
+        timeSeriesClient = new TimeSeriesClientImpl(initMockWebServer(), restTemplate);
     }
 
     @Test


### PR DESCRIPTION
Problem occurs when running dynamic-simulation-server, dynamic-mapping-server by docker-compose at local

![image](https://user-images.githubusercontent.com/117309322/218096464-46383525-483b-498a-a500-9132423b08ed.png)
