### PR TITLE
Fix Liquibase `diff` when JPA entities not modified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ target/
 # IntelliJ
 /.idea
 *.iml
+
+# https://github.com/liquibase/liquibase/issues/2196
+/derby.log

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-parent-ws</artifactId>
-        <version>17</version>
+        <version>18</version>
         <relativePath/>
     </parent>
 

--- a/src/main/resources/db/changelog/changesets/changelog_20231017T175732Z.xml
+++ b/src/main/resources/db/changelog/changesets/changelog_20231017T175732Z.xml
@@ -1,0 +1,32 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-latest.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet author="chuinetri (base generated)" id="1697565484122-1">
+        <comment>Diff from #384</comment>
+        <modifyDataType columnName="import_parameters" newDataType="varchar(255)" tableName="import_parameters"/>
+    </changeSet>
+    <changeSet author="chuinetri (base generated)" id="1697565484122-2">
+        <comment>Diff from #433</comment>
+        <dropDefaultValue columnDataType="boolean" columnName="stashed" tableName="node"/>
+    </changeSet>
+
+    <!--<changeSet author="chuinetri (base generated)" id="1697565484122-3">
+        <dropUniqueConstraint constraintName="uc_studyLoad_flow_parameters_entity_id_col" tableName="study"/>
+        <dropUniqueConstraint constraintName="uc_studyDynamic_simulation_parameters_entity_id_col" tableName="study"/>
+        <dropUniqueConstraint constraintName="uc_studyShort_circuit_parameters_entity_id_col" tableName="study"/>
+        <dropUniqueConstraint constraintName="uc_studySecurity_analysis_parameters_entity_id_col" tableName="study"/>
+        <dropUniqueConstraint constraintName="uc_studySensitivity_analysis_parameters_entity_id_col" tableName="study"/>
+    </changeSet>-->
+    <changeSet author="chuinetri (base generated)" id="1697565484122-4">
+        <addUniqueConstraint columnNames="load_flow_parameters_entity_id" constraintName="uc_studyLoad_flow_parameters_entity_id_col" tableName="study"/>
+        <addUniqueConstraint columnNames="dynamic_simulation_parameters_entity_id" constraintName="uc_studyDynamic_simulation_parameters_entity_id_col" tableName="study"/>
+        <addUniqueConstraint columnNames="short_circuit_parameters_entity_id" constraintName="uc_studyShort_circuit_parameters_entity_id_col" tableName="study"/>
+        <addUniqueConstraint columnNames="security_analysis_parameters_entity_id" constraintName="uc_studySecurity_analysis_parameters_entity_id_col" tableName="study"/>
+        <addUniqueConstraint columnNames="sensitivity_analysis_parameters_entity_id" constraintName="uc_studySensitivity_analysis_parameters_entity_id_col" tableName="study"/>
+    </changeSet>
+
+    <changeSet author="chuinetri (base generated)" id="1697565484122-5">
+        <addForeignKeyConstraint baseColumnNames="sensitivity_factor_id" baseTableName="contingencies" constraintName="sensitivityFactorEntity_contingencies_fk" deferrable="false" initiallyDeferred="false" referencedColumnNames="id" referencedTableName="sensitivity_factor_with_sensi_type_for_pst_entity" validate="true"/>
+        <addForeignKeyConstraint baseColumnNames="sensitivity_factor_id" baseTableName="injections" constraintName="sensitivityFactorEntity_injections_fk" deferrable="false" initiallyDeferred="false" referencedColumnNames="id" referencedTableName="sensitivity_factor_with_sensi_type_for_pst_entity" validate="true"/>
+        <addForeignKeyConstraint baseColumnNames="sensitivity_factor_id" baseTableName="monitored_branch" constraintName="sensitivityFactorEntity_monitoredBranch_fk" deferrable="false" initiallyDeferred="false" referencedColumnNames="id" referencedTableName="sensitivity_factor_with_sensi_type_for_pst_entity" validate="true"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changesets/changelog_20231017T181423Z.xml
+++ b/src/main/resources/db/changelog/changesets/changelog_20231017T181423Z.xml
@@ -1,0 +1,21 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-latest.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet author="chuinetri (generated)" id="1697566475067-1">
+        <dropUniqueConstraint constraintName="UC_STUDYDYNAMIC_SIMULATION_PARAMETERS_ENTITY_ID_COL" tableName="study"/>
+    </changeSet>
+    <changeSet author="chuinetri (generated)" id="1697566475067-2">
+        <addUniqueConstraint columnNames="dynamic_simulation_parameters_entity_id" constraintName="UC_STUDYDYNAMIC_SIMULATION_PARAMETERS_ENTITY_ID_COL" tableName="study"/>
+    </changeSet>
+    <changeSet author="chuinetri (generated)" id="1697566475067-3">
+        <dropUniqueConstraint constraintName="UC_STUDYSHORT_CIRCUIT_PARAMETERS_ENTITY_ID_COL" tableName="study"/>
+    </changeSet>
+    <changeSet author="chuinetri (generated)" id="1697566475067-4">
+        <addUniqueConstraint columnNames="short_circuit_parameters_entity_id" constraintName="UC_STUDYSHORT_CIRCUIT_PARAMETERS_ENTITY_ID_COL" tableName="study"/>
+    </changeSet>
+    <changeSet author="chuinetri (generated)" id="1697566475067-5">
+        <dropUniqueConstraint constraintName="UC_STUDYSENSITIVITY_ANALYSIS_PARAMETERS_ENTITY_ID_COL" tableName="study"/>
+    </changeSet>
+    <changeSet author="chuinetri (generated)" id="1697566475067-6">
+        <addUniqueConstraint columnNames="sensitivity_analysis_parameters_entity_id" constraintName="UC_STUDYSENSITIVITY_ANALYSIS_PARAMETERS_ENTITY_ID_COL" tableName="study"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,205 +1,160 @@
 databaseChangeLog:
-
   - include:
       file: changesets/changelog_20211026T203417Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20211028T065600Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20211116T135736Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20211129T161403Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20220104T094845Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20220118T160410Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20220117T104332Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20220104T095555Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20220303T144235Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20220419T140349Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20220427T124717Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20220601T124654Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20220620T113200Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20220622T124654Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20220627T123433Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20220707T091033Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20220716T115744Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20220713T103844Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20220825T134246Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20220823T140244Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20220810T144908Z.xml
       relativeToChangelogFile: true     
-
   - include:
       file: changesets/changelog_20220923T123618Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20220928T140021Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20221027T151150Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20221122T152654Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20221118T145327Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20230106T114200Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20221221T091729Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20230306T093139Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20230407T121534Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20230412T132332Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20230417T131334Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20230428T120005Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20230320T154025Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20230413T211156Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20230526T145728Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20230522T115251Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20230602T150222Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20230613T165914Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20230614T110354Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20230705T155125Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20230711T111525Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20230704T125001Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20230727T085511Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20230807T081915Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20230822T072138Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20230825T115511Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20230906T074248Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20230921T145300Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20230927T143833Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20230922T141912Z.xml
+      relativeToChangelogFile: true
+  - include:
+      file: changesets/changelog_20231017T175732Z.xml
+      relativeToChangelogFile: true
+  - include:
+      file: changesets/changelog_20231017T181423Z.xml
       relativeToChangelogFile: true

--- a/src/test/resources/application-default.yml
+++ b/src/test/resources/application-default.yml
@@ -17,8 +17,5 @@ logging:
 powsybl-ws:
   database:
     vendor: h2:mem
-    query: ;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    query: ;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=PostgreSQL;DEFAULT_NULL_ORDERING=HIGH
     hostPort: ":"
-
-
-


### PR DESCRIPTION
Liquibase `diff` generate changes when using `main` branch without modifying JPA entities.  
* The diff come from recent migrations updating some rules in Liquibase.
* Also add missing compatibility mode in H2 configuration
* ⚠️ need release v18 of powsybl/powsybl-parent/pull/54