### PR TITLE
Remove Switch and line updateType notifications

### DIFF
--- a/src/main/java/org/gridsuite/study/server/notification/NotificationService.java
+++ b/src/main/java/org/gridsuite/study/server/notification/NotificationService.java
@@ -43,7 +43,6 @@ public class NotificationService {
     public static final String UPDATE_TYPE_BUILD_CANCELLED = "buildCancelled";
     public static final String UPDATE_TYPE_BUILD_COMPLETED = "buildCompleted";
     public static final String UPDATE_TYPE_BUILD_FAILED = "buildFailed";
-    public static final String UPDATE_TYPE_LINE = "line";
     public static final String UPDATE_TYPE_LOADFLOW_RESULT = "loadflowResult";
     public static final String UPDATE_TYPE_LOADFLOW_STATUS = "loadflow_status";
     public static final String UPDATE_TYPE_LOADFLOW_FAILED = "loadflow_failed";
@@ -69,7 +68,6 @@ public class NotificationService {
     public static final String UPDATE_TYPE_STUDY_NETWORK_RECREATION_DONE = "study_network_recreation_done";
     public static final String UPDATE_TYPE_STUDY = "study";
     public static final String UPDATE_TYPE_STUDY_METADATA_UPDATED = "metadata_updated";
-    public static final String UPDATE_TYPE_SWITCH = "switch";
     public static final String UPDATE_TYPE_INDEXATION_STATUS = "indexation_status_updated";
 
     public static final String MODIFICATIONS_CREATING_IN_PROGRESS = "creatingInProgress";

--- a/src/main/java/org/gridsuite/study/server/service/StudyService.java
+++ b/src/main/java/org/gridsuite/study/server/service/StudyService.java
@@ -1831,18 +1831,6 @@ public class StudyService {
                 .impactedSubstationsIds(networkModificationResult.getImpactedSubstationsIds())
                 .build()
         );
-
-        if (networkModificationResult.getNetworkImpacts().stream()
-            .filter(impact -> impact.getImpactType() == SimpleImpactType.MODIFICATION)
-            .anyMatch(impact -> impact.getElementType() == IdentifiableType.SWITCH)) {
-            notificationService.emitStudyChanged(studyUuid, nodeUuid, NotificationService.UPDATE_TYPE_SWITCH);
-        }
-
-        if (networkModificationResult.getNetworkImpacts().stream()
-            .filter(impact -> impact.getImpactType() == SimpleImpactType.MODIFICATION)
-            .anyMatch(impact -> impact.getElementType() == IdentifiableType.LINE)) {
-            notificationService.emitStudyChanged(studyUuid, nodeUuid, NotificationService.UPDATE_TYPE_LINE);
-        }
     }
 
     public void notify(@NonNull String notificationName, @NonNull UUID studyUuid) {

--- a/src/test/java/org/gridsuite/study/server/NetworkModificationTest.java
+++ b/src/test/java/org/gridsuite/study/server/NetworkModificationTest.java
@@ -2628,14 +2628,6 @@ public class NetworkModificationTest {
 
         checkEquipmentMessagesReceived(studyNameUserIdUuid, nodeUuids, expectedPayload);
 
-        // assert that the broker message has been sent
-        Message<byte[]> messageSwitch = output.receive(TIMEOUT, studyUpdateDestination);
-        assertEquals("", new String(messageSwitch.getPayload()));
-        MessageHeaders headersSwitch = messageSwitch.getHeaders();
-        assertEquals(studyNameUserIdUuid, headersSwitch.get(NotificationService.HEADER_STUDY_UUID));
-        assertEquals(nodeUuids.get(0), headersSwitch.get(NotificationService.HEADER_NODE));
-        assertEquals(NotificationService.UPDATE_TYPE_SWITCH, headersSwitch.get(NotificationService.HEADER_UPDATE_TYPE));
-
         checkNodesBuildStatusUpdatedMessageReceived(studyNameUserIdUuid, nodeUuids);
         checkUpdateModelsStatusMessagesReceived(studyNameUserIdUuid, nodeUuids.get(0));
     }


### PR DESCRIPTION
tests done : 
* change switch state on a SLD
* lock out line on SLD
* trip line on SLD

No trace found of consumption of those notifications in front apps.