### PR TITLE
Add annotations to disable SQL/JPA & AMQP

### DIFF
--- a/src/test/java/org/gridsuite/study/server/config/DisableAmqp.java
+++ b/src/test/java/org/gridsuite/study/server/config/DisableAmqp.java
@@ -16,7 +16,7 @@ import java.lang.annotation.*;
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 @MockBean(StreamBridge.class) //use by NotificationService
-@TestPropertySource(properties = DisableAmqp.PROPERTY_NAME + "=false")
+@TestPropertySource(properties = DisableAmqp.PROPERTY_NAME + "=true")
 public @interface DisableAmqp {
-    String PROPERTY_NAME = "test.enable.amqp";
+    String PROPERTY_NAME = "test.disable.amqp";
 }

--- a/src/test/java/org/gridsuite/study/server/config/DisableAmqp.java
+++ b/src/test/java/org/gridsuite/study/server/config/DisableAmqp.java
@@ -16,7 +16,7 @@ import java.lang.annotation.*;
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 @MockBean(StreamBridge.class) //use by NotificationService
-@TestPropertySource(properties = DisableAmqp.PROPERTY_NAME + "=true")
+@TestPropertySource(properties = DisableAmqp.PROPERTY_NAME + "=false")
 public @interface DisableAmqp {
-    String PROPERTY_NAME = "test.disable.amqp";
+    String PROPERTY_NAME = "test.enable.amqp";
 }

--- a/src/test/java/org/gridsuite/study/server/config/DisableAmqp.java
+++ b/src/test/java/org/gridsuite/study/server/config/DisableAmqp.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.gridsuite.study.server.config;
+
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cloud.stream.function.StreamBridge;
+import org.springframework.test.context.TestPropertySource;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@MockBean(StreamBridge.class) //use by NotificationService
+@TestPropertySource(properties = DisableAmqp.PROPERTY_NAME+"=true")
+public @interface DisableAmqp {
+    String PROPERTY_NAME = "test.disable.amqp";
+}

--- a/src/test/java/org/gridsuite/study/server/config/DisableAmqp.java
+++ b/src/test/java/org/gridsuite/study/server/config/DisableAmqp.java
@@ -16,7 +16,7 @@ import java.lang.annotation.*;
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 @MockBean(StreamBridge.class) //use by NotificationService
-@TestPropertySource(properties = DisableAmqp.PROPERTY_NAME+"=true")
+@TestPropertySource(properties = DisableAmqp.PROPERTY_NAME + "=true")
 public @interface DisableAmqp {
     String PROPERTY_NAME = "test.disable.amqp";
 }

--- a/src/test/java/org/gridsuite/study/server/config/DisableCloudStream.java
+++ b/src/test/java/org/gridsuite/study/server/config/DisableCloudStream.java
@@ -6,8 +6,8 @@
  */
 package org.gridsuite.study.server.config;
 
+import org.gridsuite.study.server.notification.NotificationService;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.cloud.stream.function.StreamBridge;
 import org.springframework.test.context.TestPropertySource;
 
 import java.lang.annotation.*;
@@ -15,8 +15,8 @@ import java.lang.annotation.*;
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
-@MockBean(StreamBridge.class) //use by NotificationService
-@TestPropertySource(properties = DisableAmqp.PROPERTY_NAME + "=true")
-public @interface DisableAmqp {
-    String PROPERTY_NAME = "test.disable.amqp";
+@MockBean(NotificationService.class)
+@TestPropertySource(properties = DisableCloudStream.DISABLE_PROPERTY_NAME + "=true")
+public @interface DisableCloudStream {
+    String DISABLE_PROPERTY_NAME = "test.disable.cloud-stream";
 }

--- a/src/test/java/org/gridsuite/study/server/config/DisableJpa.java
+++ b/src/test/java/org/gridsuite/study/server/config/DisableJpa.java
@@ -29,7 +29,7 @@ import java.lang.annotation.*;
 @MockBean(NodeRepository.class)
 @MockBean(RootNodeInfoRepository.class)
 //@MockBean(NetworkModificationTreeService.class) //TODO mockBean NetworkModificationNodeInfoRepository not found ?
-@TestPropertySource(properties = DisableJpa.PROPERTY_NAME + "=true") //can't have multiple @EnableAutoConfiguration(exclude)
+@TestPropertySource(properties = DisableJpa.PROPERTY_NAME + "=false") //can't have multiple @EnableAutoConfiguration(exclude)
 public @interface DisableJpa {
-    String PROPERTY_NAME = "test.disable.jpa";
+    String PROPERTY_NAME = "test.enable.jpa";
 }

--- a/src/test/java/org/gridsuite/study/server/config/DisableJpa.java
+++ b/src/test/java/org/gridsuite/study/server/config/DisableJpa.java
@@ -29,7 +29,7 @@ import java.lang.annotation.*;
 @MockBean(NodeRepository.class)
 @MockBean(RootNodeInfoRepository.class)
 //@MockBean(NetworkModificationTreeService.class) //TODO mockBean NetworkModificationNodeInfoRepository not found ?
-@TestPropertySource(properties = DisableJpa.PROPERTY_NAME + "=false") //can't have multiple @EnableAutoConfiguration(exclude)
+@TestPropertySource(properties = DisableJpa.PROPERTY_NAME + "=true") //can't have multiple @EnableAutoConfiguration(exclude)
 public @interface DisableJpa {
-    String PROPERTY_NAME = "test.enable.jpa";
+    String PROPERTY_NAME = "test.disable.jpa";
 }

--- a/src/test/java/org/gridsuite/study/server/config/DisableJpa.java
+++ b/src/test/java/org/gridsuite/study/server/config/DisableJpa.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.gridsuite.study.server.config;
+
+import jakarta.persistence.EntityManagerFactory;
+import org.gridsuite.study.server.repository.StudyCreationRequestRepository;
+import org.gridsuite.study.server.repository.StudyRepository;
+import org.gridsuite.study.server.repository.dynamicsimulation.EventRepository;
+import org.gridsuite.study.server.repository.networkmodificationtree.NetworkModificationNodeInfoRepository;
+import org.gridsuite.study.server.repository.networkmodificationtree.NodeRepository;
+import org.gridsuite.study.server.repository.networkmodificationtree.RootNodeInfoRepository;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.TestPropertySource;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@MockBean(classes = EntityManagerFactory.class, name = "jpaSharedEM_entityManagerFactory")
+@MockBean(StudyRepository.class)
+@MockBean(StudyCreationRequestRepository.class)
+@MockBean(EventRepository.class)
+@MockBean(NetworkModificationNodeInfoRepository.class)
+@MockBean(NodeRepository.class)
+@MockBean(RootNodeInfoRepository.class)
+//@MockBean(NetworkModificationTreeService.class) //TODO mockBean NetworkModificationNodeInfoRepository not found ?
+@TestPropertySource(properties = DisableJpa.PROPERTY_NAME+"=true") //can't have multiple @EnableAutoConfiguration(exclude)
+public @interface DisableJpa {
+    String PROPERTY_NAME = "test.disable.jpa";
+}

--- a/src/test/java/org/gridsuite/study/server/config/DisableJpa.java
+++ b/src/test/java/org/gridsuite/study/server/config/DisableJpa.java
@@ -29,7 +29,7 @@ import java.lang.annotation.*;
 @MockBean(NodeRepository.class)
 @MockBean(RootNodeInfoRepository.class)
 //@MockBean(NetworkModificationTreeService.class) //TODO mockBean NetworkModificationNodeInfoRepository not found ?
-@TestPropertySource(properties = DisableJpa.PROPERTY_NAME+"=true") //can't have multiple @EnableAutoConfiguration(exclude)
+@TestPropertySource(properties = DisableJpa.PROPERTY_NAME + "=true") //can't have multiple @EnableAutoConfiguration(exclude)
 public @interface DisableJpa {
     String PROPERTY_NAME = "test.disable.jpa";
 }

--- a/src/test/java/org/gridsuite/study/server/config/DisableJpa.java
+++ b/src/test/java/org/gridsuite/study/server/config/DisableJpa.java
@@ -6,7 +6,6 @@
  */
 package org.gridsuite.study.server.config;
 
-import jakarta.persistence.EntityManagerFactory;
 import org.gridsuite.study.server.repository.StudyCreationRequestRepository;
 import org.gridsuite.study.server.repository.StudyRepository;
 import org.gridsuite.study.server.repository.dynamicsimulation.EventRepository;
@@ -21,15 +20,13 @@ import java.lang.annotation.*;
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
-@MockBean(classes = EntityManagerFactory.class, name = "jpaSharedEM_entityManagerFactory")
 @MockBean(StudyRepository.class)
 @MockBean(StudyCreationRequestRepository.class)
 @MockBean(EventRepository.class)
 @MockBean(NetworkModificationNodeInfoRepository.class)
 @MockBean(NodeRepository.class)
 @MockBean(RootNodeInfoRepository.class)
-//@MockBean(NetworkModificationTreeService.class) //TODO mockBean NetworkModificationNodeInfoRepository not found ?
-@TestPropertySource(properties = DisableJpa.PROPERTY_NAME + "=true") //can't have multiple @EnableAutoConfiguration(exclude)
+@TestPropertySource(properties = DisableJpa.DISABLE_PROPERTY_NAME + "=true")
 public @interface DisableJpa {
-    String PROPERTY_NAME = "test.disable.jpa";
+    String DISABLE_PROPERTY_NAME = "test.disable.data-jpa";
 }

--- a/src/test/java/org/gridsuite/study/server/config/ExcludeSpringBootTestComponents.java
+++ b/src/test/java/org/gridsuite/study/server/config/ExcludeSpringBootTestComponents.java
@@ -42,12 +42,12 @@ import java.util.Set;
  * @see DisableJpa
  * @see DisableAmqp
  */
-@NoArgsConstructor(onConstructor_={ @Autowired })
+@NoArgsConstructor(onConstructor_ = { @Autowired })
 @ToString(onlyExplicitlyIncluded = true)
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Slf4j
 public class ExcludeSpringBootTestComponents implements AutoConfigurationImportFilter, EnvironmentAware {
-    @Setter(onMethod_={@Override})
+    @Setter(onMethod_ = {@Override})
     private Environment environment;
 
     /**

--- a/src/test/java/org/gridsuite/study/server/config/ExcludeSpringBootTestComponents.java
+++ b/src/test/java/org/gridsuite/study/server/config/ExcludeSpringBootTestComponents.java
@@ -7,16 +7,16 @@
 package org.gridsuite.study.server.config;
 
 import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
-import lombok.extern.slf4j.Slf4j;
 import org.gridsuite.study.server.utils.elasticsearch.DisableElasticsearch;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.AutoConfigurationImportFilter;
 import org.springframework.boot.autoconfigure.AutoConfigurationMetadata;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration;
+import org.springframework.boot.autoconfigure.cache.CacheAutoConfiguration;
 import org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchDataAutoConfiguration;
 import org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchRepositoriesAutoConfiguration;
 import org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration;
@@ -40,14 +40,14 @@ import java.util.Set;
  *
  * @see org.gridsuite.study.server.utils.elasticsearch.DisableElasticsearch
  * @see DisableJpa
- * @see DisableAmqp
+ * @see DisableCloudStream
  */
-@NoArgsConstructor(onConstructor_ = { @Autowired })
-@ToString(onlyExplicitlyIncluded = true)
+@ToString(onlyExplicitlyIncluded = true) //create a beautiful toString() with only the class-name
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
-@Slf4j
 public class ExcludeSpringBootTestComponents implements AutoConfigurationImportFilter, EnvironmentAware {
-    @Setter(onMethod_ = {@Override})
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExcludeSpringBootTestComponents.class);
+
+    @Setter
     private Environment environment;
 
     /**
@@ -56,32 +56,33 @@ public class ExcludeSpringBootTestComponents implements AutoConfigurationImportF
     @Override
     public boolean[] match(final String[] autoConfigurationClasses, final AutoConfigurationMetadata autoConfigurationMetadata) {
         final Set<String> autoConfigDisable = new HashSet<>();
-        if (environment.getProperty(DisableJpa.PROPERTY_NAME, Boolean.class, Boolean.FALSE)) {
-            log.debug("Disabling SQL & JPA Autoconfiguration");
+        if (environment.getProperty(DisableJpa.DISABLE_PROPERTY_NAME, Boolean.class, Boolean.FALSE)) {
+            LOGGER.debug("Disabling SQL & JPA Autoconfiguration");
             autoConfigDisable.add(DataSourceAutoConfiguration.class.getName());
             autoConfigDisable.add(JpaRepositoriesAutoConfiguration.class.getName());
             autoConfigDisable.add(HibernateJpaAutoConfiguration.class.getName());
             autoConfigDisable.add(LiquibaseAutoConfiguration.class.getName());
+            autoConfigDisable.add(CacheAutoConfiguration.class.getName());
         }
-        if (environment.getProperty(DisableElasticsearch.PROPERTY_NAME, Boolean.class, Boolean.FALSE)) {
-            log.debug("Disabling ElasticSearch Autoconfiguration");
+        if (environment.getProperty(DisableElasticsearch.DISABLE_PROPERTY_NAME, Boolean.class, Boolean.FALSE)) {
+            LOGGER.debug("Disabling ElasticSearch Autoconfiguration");
             autoConfigDisable.add(ElasticsearchClientAutoConfiguration.class.getName());
             autoConfigDisable.add(ElasticsearchDataAutoConfiguration.class.getName());
             autoConfigDisable.add(ElasticsearchRestClientAutoConfiguration.class.getName());
             autoConfigDisable.add(ElasticsearchRepositoriesAutoConfiguration.class.getName());
         }
-        if (environment.getProperty(DisableAmqp.PROPERTY_NAME, Boolean.class, Boolean.FALSE)) {
-            log.debug("Disabling AMQP Autoconfiguration");
+        if (environment.getProperty(DisableCloudStream.DISABLE_PROPERTY_NAME, Boolean.class, Boolean.FALSE)) {
+            LOGGER.debug("Disabling AMQP Autoconfiguration");
             autoConfigDisable.add(RabbitAutoConfiguration.class.getName());
             autoConfigDisable.add(FunctionConfiguration.class.getName());
             autoConfigDisable.add(BindingServiceConfiguration.class.getName());
         }
-        log.trace("Classes not allowed for autoconfiguration: {}", autoConfigDisable);
+        LOGGER.trace("Classes not allowed for autoconfiguration: {}", autoConfigDisable);
         boolean[] passed = new boolean[autoConfigurationClasses.length];
         for (int i = 0; i < autoConfigurationClasses.length; i++) {
             passed[i] = !autoConfigDisable.contains(autoConfigurationClasses[i]);
         }
-        log.trace("Result filtering classes {} → {}", autoConfigurationClasses, passed);
+        LOGGER.trace("Result filtering classes {} → {}", autoConfigurationClasses, passed);
         return passed;
     }
 }

--- a/src/test/java/org/gridsuite/study/server/config/ExcludeSpringBootTestComponents.java
+++ b/src/test/java/org/gridsuite/study/server/config/ExcludeSpringBootTestComponents.java
@@ -56,21 +56,21 @@ public class ExcludeSpringBootTestComponents implements AutoConfigurationImportF
     @Override
     public boolean[] match(final String[] autoConfigurationClasses, final AutoConfigurationMetadata autoConfigurationMetadata) {
         final Set<String> autoConfigDisable = new HashSet<>();
-        if (environment.getProperty(DisableJpa.PROPERTY_NAME, Boolean.class, Boolean.FALSE)) {
+        if (!environment.getProperty(DisableJpa.PROPERTY_NAME, Boolean.class, Boolean.TRUE)) {
             log.debug("Disabling SQL & JPA Autoconfiguration");
             autoConfigDisable.add(DataSourceAutoConfiguration.class.getName());
             autoConfigDisable.add(JpaRepositoriesAutoConfiguration.class.getName());
             autoConfigDisable.add(HibernateJpaAutoConfiguration.class.getName());
             autoConfigDisable.add(LiquibaseAutoConfiguration.class.getName());
         }
-        if (environment.getProperty(DisableElasticsearch.PROPERTY_NAME, Boolean.class, Boolean.FALSE)) {
+        if (!environment.getProperty(DisableElasticsearch.PROPERTY_NAME, Boolean.class, Boolean.TRUE)) {
             log.debug("Disabling ElasticSearch Autoconfiguration");
             autoConfigDisable.add(ElasticsearchClientAutoConfiguration.class.getName());
             autoConfigDisable.add(ElasticsearchDataAutoConfiguration.class.getName());
             autoConfigDisable.add(ElasticsearchRestClientAutoConfiguration.class.getName());
             autoConfigDisable.add(ElasticsearchRepositoriesAutoConfiguration.class.getName());
         }
-        if (environment.getProperty(DisableAmqp.PROPERTY_NAME, Boolean.class, Boolean.FALSE)) {
+        if (!environment.getProperty(DisableAmqp.PROPERTY_NAME, Boolean.class, Boolean.TRUE)) {
             log.debug("Disabling AMQP Autoconfiguration");
             autoConfigDisable.add(RabbitAutoConfiguration.class.getName());
             autoConfigDisable.add(FunctionConfiguration.class.getName());

--- a/src/test/java/org/gridsuite/study/server/config/ExcludeSpringBootTestComponents.java
+++ b/src/test/java/org/gridsuite/study/server/config/ExcludeSpringBootTestComponents.java
@@ -56,21 +56,21 @@ public class ExcludeSpringBootTestComponents implements AutoConfigurationImportF
     @Override
     public boolean[] match(final String[] autoConfigurationClasses, final AutoConfigurationMetadata autoConfigurationMetadata) {
         final Set<String> autoConfigDisable = new HashSet<>();
-        if (!environment.getProperty(DisableJpa.PROPERTY_NAME, Boolean.class, Boolean.TRUE)) {
+        if (environment.getProperty(DisableJpa.PROPERTY_NAME, Boolean.class, Boolean.FALSE)) {
             log.debug("Disabling SQL & JPA Autoconfiguration");
             autoConfigDisable.add(DataSourceAutoConfiguration.class.getName());
             autoConfigDisable.add(JpaRepositoriesAutoConfiguration.class.getName());
             autoConfigDisable.add(HibernateJpaAutoConfiguration.class.getName());
             autoConfigDisable.add(LiquibaseAutoConfiguration.class.getName());
         }
-        if (!environment.getProperty(DisableElasticsearch.PROPERTY_NAME, Boolean.class, Boolean.TRUE)) {
+        if (environment.getProperty(DisableElasticsearch.PROPERTY_NAME, Boolean.class, Boolean.FALSE)) {
             log.debug("Disabling ElasticSearch Autoconfiguration");
             autoConfigDisable.add(ElasticsearchClientAutoConfiguration.class.getName());
             autoConfigDisable.add(ElasticsearchDataAutoConfiguration.class.getName());
             autoConfigDisable.add(ElasticsearchRestClientAutoConfiguration.class.getName());
             autoConfigDisable.add(ElasticsearchRepositoriesAutoConfiguration.class.getName());
         }
-        if (!environment.getProperty(DisableAmqp.PROPERTY_NAME, Boolean.class, Boolean.TRUE)) {
+        if (environment.getProperty(DisableAmqp.PROPERTY_NAME, Boolean.class, Boolean.FALSE)) {
             log.debug("Disabling AMQP Autoconfiguration");
             autoConfigDisable.add(RabbitAutoConfiguration.class.getName());
             autoConfigDisable.add(FunctionConfiguration.class.getName());

--- a/src/test/java/org/gridsuite/study/server/config/ExcludeSpringBootTestComponents.java
+++ b/src/test/java/org/gridsuite/study/server/config/ExcludeSpringBootTestComponents.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.gridsuite.study.server.config;
+
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+import org.gridsuite.study.server.utils.elasticsearch.DisableElasticsearch;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfigurationImportFilter;
+import org.springframework.boot.autoconfigure.AutoConfigurationMetadata;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchDataAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchRepositoriesAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration;
+import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
+import org.springframework.cloud.stream.config.BindingServiceConfiguration;
+import org.springframework.cloud.stream.function.FunctionConfiguration;
+import org.springframework.context.EnvironmentAware;
+import org.springframework.core.env.Environment;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * This classe is to permit with {@code @Disable*} annotations to exclude some components from auto-configuration
+ * when using {@link org.springframework.boot.test.context.SpringBootTest @SpringBootTest}.<br/>
+ * It works the same way as {@link EnableAutoConfiguration#exclude()} but is usable by multiple annotations.
+ *
+ * @see org.gridsuite.study.server.utils.elasticsearch.DisableElasticsearch
+ * @see DisableJpa
+ * @see DisableAmqp
+ */
+@NoArgsConstructor(onConstructor_={ @Autowired })
+@ToString(onlyExplicitlyIncluded = true)
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@Slf4j
+public class ExcludeSpringBootTestComponents implements AutoConfigurationImportFilter, EnvironmentAware {
+    @Setter(onMethod_={@Override})
+    private Environment environment;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean[] match(final String[] autoConfigurationClasses, final AutoConfigurationMetadata autoConfigurationMetadata) {
+        final Set<String> autoConfigDisable = new HashSet<>();
+        if (environment.getProperty(DisableJpa.PROPERTY_NAME, Boolean.class, Boolean.FALSE)) {
+            log.debug("Disabling SQL & JPA Autoconfiguration");
+            autoConfigDisable.add(DataSourceAutoConfiguration.class.getName());
+            autoConfigDisable.add(JpaRepositoriesAutoConfiguration.class.getName());
+            autoConfigDisable.add(HibernateJpaAutoConfiguration.class.getName());
+            autoConfigDisable.add(LiquibaseAutoConfiguration.class.getName());
+        }
+        if (environment.getProperty(DisableElasticsearch.PROPERTY_NAME, Boolean.class, Boolean.FALSE)) {
+            log.debug("Disabling ElasticSearch Autoconfiguration");
+            autoConfigDisable.add(ElasticsearchClientAutoConfiguration.class.getName());
+            autoConfigDisable.add(ElasticsearchDataAutoConfiguration.class.getName());
+            autoConfigDisable.add(ElasticsearchRestClientAutoConfiguration.class.getName());
+            autoConfigDisable.add(ElasticsearchRepositoriesAutoConfiguration.class.getName());
+        }
+        if (environment.getProperty(DisableAmqp.PROPERTY_NAME, Boolean.class, Boolean.FALSE)) {
+            log.debug("Disabling AMQP Autoconfiguration");
+            autoConfigDisable.add(RabbitAutoConfiguration.class.getName());
+            autoConfigDisable.add(FunctionConfiguration.class.getName());
+            autoConfigDisable.add(BindingServiceConfiguration.class.getName());
+        }
+        log.trace("Classes not allowed for autoconfiguration: {}", autoConfigDisable);
+        boolean[] passed = new boolean[autoConfigurationClasses.length];
+        for (int i = 0; i < autoConfigurationClasses.length; i++) {
+            passed[i] = !autoConfigDisable.contains(autoConfigurationClasses[i]);
+        }
+        log.trace("Result filtering classes {} → {}", autoConfigurationClasses, passed);
+        return passed;
+    }
+}

--- a/src/test/java/org/gridsuite/study/server/utils/elasticsearch/DisableElasticsearch.java
+++ b/src/test/java/org/gridsuite/study/server/utils/elasticsearch/DisableElasticsearch.java
@@ -4,27 +4,27 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-
 package org.gridsuite.study.server.utils.elasticsearch;
 
 import org.gridsuite.study.server.elasticsearch.EquipmentInfosRepository;
 import org.gridsuite.study.server.elasticsearch.StudyInfosRepository;
 import org.gridsuite.study.server.elasticsearch.TombstonedEquipmentInfosRepository;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.MockBeans;
+import org.springframework.test.context.TestPropertySource;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-
+import java.lang.annotation.*;
 
 /**
  * @author Slimane Amar <slimane.amar at rte-france.com>
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-@MockBeans({@MockBean(EmbeddedElasticsearch.class), @MockBean(EquipmentInfosRepository.class),
-    @MockBean(StudyInfosRepository.class), @MockBean(TombstonedEquipmentInfosRepository.class)})
+@Inherited
+@MockBean(EmbeddedElasticsearch.class)
+@MockBean(EquipmentInfosRepository.class)
+@MockBean(StudyInfosRepository.class)
+@MockBean(TombstonedEquipmentInfosRepository.class)
+@TestPropertySource(properties = DisableElasticsearch.PROPERTY_NAME+"=true")
 public @interface DisableElasticsearch {
+    String PROPERTY_NAME = "test.disable.elasticsearch";
 }

--- a/src/test/java/org/gridsuite/study/server/utils/elasticsearch/DisableElasticsearch.java
+++ b/src/test/java/org/gridsuite/study/server/utils/elasticsearch/DisableElasticsearch.java
@@ -24,7 +24,7 @@ import java.lang.annotation.*;
 @MockBean(EquipmentInfosRepository.class)
 @MockBean(StudyInfosRepository.class)
 @MockBean(TombstonedEquipmentInfosRepository.class)
-@TestPropertySource(properties = DisableElasticsearch.PROPERTY_NAME + "=false")
+@TestPropertySource(properties = DisableElasticsearch.PROPERTY_NAME + "=true")
 public @interface DisableElasticsearch {
-    String PROPERTY_NAME = "test.enable.elasticsearch";
+    String PROPERTY_NAME = "test.disable.elasticsearch";
 }

--- a/src/test/java/org/gridsuite/study/server/utils/elasticsearch/DisableElasticsearch.java
+++ b/src/test/java/org/gridsuite/study/server/utils/elasticsearch/DisableElasticsearch.java
@@ -24,7 +24,7 @@ import java.lang.annotation.*;
 @MockBean(EquipmentInfosRepository.class)
 @MockBean(StudyInfosRepository.class)
 @MockBean(TombstonedEquipmentInfosRepository.class)
-@TestPropertySource(properties = DisableElasticsearch.PROPERTY_NAME + "=true")
+@TestPropertySource(properties = DisableElasticsearch.DISABLE_PROPERTY_NAME + "=true")
 public @interface DisableElasticsearch {
-    String PROPERTY_NAME = "test.disable.elasticsearch";
+    String DISABLE_PROPERTY_NAME = "test.disable.data-elasticsearch";
 }

--- a/src/test/java/org/gridsuite/study/server/utils/elasticsearch/DisableElasticsearch.java
+++ b/src/test/java/org/gridsuite/study/server/utils/elasticsearch/DisableElasticsearch.java
@@ -24,7 +24,7 @@ import java.lang.annotation.*;
 @MockBean(EquipmentInfosRepository.class)
 @MockBean(StudyInfosRepository.class)
 @MockBean(TombstonedEquipmentInfosRepository.class)
-@TestPropertySource(properties = DisableElasticsearch.PROPERTY_NAME+"=true")
+@TestPropertySource(properties = DisableElasticsearch.PROPERTY_NAME + "=true")
 public @interface DisableElasticsearch {
     String PROPERTY_NAME = "test.disable.elasticsearch";
 }

--- a/src/test/java/org/gridsuite/study/server/utils/elasticsearch/DisableElasticsearch.java
+++ b/src/test/java/org/gridsuite/study/server/utils/elasticsearch/DisableElasticsearch.java
@@ -24,7 +24,7 @@ import java.lang.annotation.*;
 @MockBean(EquipmentInfosRepository.class)
 @MockBean(StudyInfosRepository.class)
 @MockBean(TombstonedEquipmentInfosRepository.class)
-@TestPropertySource(properties = DisableElasticsearch.PROPERTY_NAME + "=true")
+@TestPropertySource(properties = DisableElasticsearch.PROPERTY_NAME + "=false")
 public @interface DisableElasticsearch {
-    String PROPERTY_NAME = "test.disable.elasticsearch";
+    String PROPERTY_NAME = "test.enable.elasticsearch";
 }

--- a/src/test/resources/META-INF/spring.factories
+++ b/src/test/resources/META-INF/spring.factories
@@ -1,0 +1,3 @@
+# Auto Configuration Import Filters
+org.springframework.boot.autoconfigure.AutoConfigurationImportFilter=\
+org.gridsuite.study.server.config.ExcludeSpringBootTestComponents


### PR DESCRIPTION
Add `@DisableJPA` & `@DisableAmqp`, like exisitng `@DisableElasticsearch` for disabling part of Spring during `@SpringBootTest` tests.

When adding annotation on a test class with `@SpringBootTest`, we set some annotations for:
  * `@MockBean` to replace beans/classes (like jpa repositories) need by for example services; or bean like amqp streambridge which isn't init/created
  * `@TestPropertySource` to set spring property, use by filter (see below)

Spring-Boot will during its auto-configuration discover the filter via `spring.factories` file, and call it which permit us to exclude some parts from initialization.