### PR TITLE
fix: shortcircuit results deletion must reset to null both all-buses and one-bus results

### DIFF
--- a/src/main/java/org/gridsuite/study/server/service/SupervisionService.java
+++ b/src/main/java/org/gridsuite/study/server/service/SupervisionService.java
@@ -176,7 +176,10 @@ public class SupervisionService {
         AtomicReference<Long> startTime = new AtomicReference<>();
         startTime.set(System.nanoTime());
         List<NetworkModificationNodeInfoEntity> nodes = networkModificationNodeInfoRepository.findAllByShortCircuitAnalysisResultUuidNotNull();
-        nodes.stream().forEach(node -> node.setShortCircuitAnalysisResultUuid(null));
+        nodes.stream().forEach(node -> {
+            node.setShortCircuitAnalysisResultUuid(null);
+            node.setOneBusShortCircuitAnalysisResultUuid(null);
+        });
         Map<UUID, String> subreportToDelete = formatSubreportMap(ComputationType.SHORT_CIRCUIT.subReporterKey, nodes);
         reportService.deleteTreeReports(subreportToDelete);
         shortCircuitService.deleteShortCircuitAnalysisResults();


### PR DESCRIPTION
All short-circuit results are removed in the "shortcircuit" database, but:
- When we call _delete_computation_results.py_ admin tool before this PR, only all-buses results are reset to null in the study database.
- Now one-bus results are set to null too.