### PR TITLE
Add environment variable for embedded ES container

### DIFF
--- a/src/test/java/org/gridsuite/study/server/utils/elasticsearch/EmbeddedElasticsearch.java
+++ b/src/test/java/org/gridsuite/study/server/utils/elasticsearch/EmbeddedElasticsearch.java
@@ -12,6 +12,8 @@ import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 
+import java.util.Map;
+
 /**
  * A class to launch an embedded DB elasticsearch
  *
@@ -32,8 +34,13 @@ public class EmbeddedElasticsearch {
         }
 
         elasticsearchContainer = new ElasticsearchContainer(String.format("%s:%s", ES_DOCKER_IMAGE_NAME, ES_DOCKER_IMAGE_VERSION));
+        Map<String, String> envMap = elasticsearchContainer.getEnvMap();
+        envMap.put("discovery.type", "single-node");
+        envMap.put("LOGSPOUT", "ignore");
         //Els 8 has security enabled by default
-        elasticsearchContainer.getEnvMap().put("xpack.security.enabled", Boolean.FALSE.toString());
+        envMap.put("xpack.security.enabled", Boolean.FALSE.toString());
+        envMap.put("ingest.geoip.downloader.enabled", Boolean.FALSE.toString());
+        envMap.put("ES_JAVA_OPTS", "-Xms128m -Xmx128m");
         elasticsearchContainer.start();
 
         System.setProperty("spring.data.elasticsearch.embedded", Boolean.toString(true));


### PR DESCRIPTION
* Add same environment variables for the embedded elastic search container as in docker-compose.
* Limit the memory (Xms/Xmx) to 128m because since ES 7.11.0, heap settings are based on node roles and total system memory [#65905](https://github.com/elastic/elasticsearch/pull/65905). Heap memory default values are computed as :
`50% of total system memory when greater than 1 gigabyte up to a maximum of 31 gigabytes`
cf. https://github.com/gridsuite/deployment/commit/42d43729424b87040a724df027f8bd8d9cb41b1f.
We cannot accept to allocate 16Go for an embedded ES.