### PR TITLE
Dynamic Simulation - Exception when running simulation without curves

### DIFF
--- a/src/main/java/org/gridsuite/study/server/StudyController.java
+++ b/src/main/java/org/gridsuite/study/server/StudyController.java
@@ -42,6 +42,7 @@ import org.gridsuite.study.server.service.shortcircuit.ShortcircuitAnalysisType;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.util.Pair;
 import org.springframework.http.*;
+import org.springframework.util.CollectionUtils;
 import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.*;
 
@@ -1568,44 +1569,44 @@ public class StudyController {
     @GetMapping(value = "/studies/{studyUuid}/nodes/{nodeUuid}/dynamic-simulation/result/timeseries/metadata")
     @Operation(summary = "Get list of time series metadata of dynamic simulation result on study")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Time series metadata of dynamic simulation result"),
-        @ApiResponse(responseCode = "204", description = "No dynamic simulation has been done yet"),
+        @ApiResponse(responseCode = "204", description = "No dynamic simulation metadata"),
         @ApiResponse(responseCode = "404", description = "The dynamic simulation has not been found")})
     public ResponseEntity<List<TimeSeriesMetadataInfos>> getDynamicSimulationTimeSeriesMetadata(@Parameter(description = "study UUID") @PathVariable("studyUuid") UUID studyUuid,
                                                                                                 @Parameter(description = "nodeUuid") @PathVariable("nodeUuid") UUID nodeUuid) {
         List<TimeSeriesMetadataInfos> result = studyService.getDynamicSimulationTimeSeriesMetadata(nodeUuid);
-        return result != null ? ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(result) :
-                ResponseEntity.noContent().build();
+        return CollectionUtils.isEmpty(result) ? ResponseEntity.noContent().build() :
+                ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(result);
     }
 
     @GetMapping(value = "/studies/{studyUuid}/nodes/{nodeUuid}/dynamic-simulation/result/timeseries")
     @Operation(summary = "Get all time series of dynamic simulation result on study")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "All time series of dynamic simulation result"),
-        @ApiResponse(responseCode = "204", description = "No dynamic simulation has been done yet"),
+        @ApiResponse(responseCode = "204", description = "No dynamic simulation timeseries"),
         @ApiResponse(responseCode = "404", description = "The dynamic simulation has not been found")})
     public ResponseEntity<List<DoubleTimeSeries>> getDynamicSimulationTimeSeriesResult(@Parameter(description = "study UUID") @PathVariable("studyUuid") UUID studyUuid,
                                                                                        @Parameter(description = "nodeUuid") @PathVariable("nodeUuid") UUID nodeUuid,
                                                                                        @Parameter(description = "timeSeriesNames") @RequestParam(name = "timeSeriesNames", required = false) List<String> timeSeriesNames) {
         List<DoubleTimeSeries> result = studyService.getDynamicSimulationTimeSeries(nodeUuid, timeSeriesNames);
-        return result != null ? ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(result) :
-                ResponseEntity.noContent().build();
+        return CollectionUtils.isEmpty(result) ? ResponseEntity.noContent().build() :
+                ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(result);
     }
 
     @GetMapping(value = "/studies/{studyUuid}/nodes/{nodeUuid}/dynamic-simulation/result/timeline")
     @Operation(summary = "Get a timeline of dynamic simulation result on study")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "The timeline of dynamic simulation result"),
-        @ApiResponse(responseCode = "204", description = "No dynamic simulation has been done yet"),
+        @ApiResponse(responseCode = "204", description = "No dynamic simulation timeline"),
         @ApiResponse(responseCode = "404", description = "The dynamic simulation has not been found")})
     public ResponseEntity<List<StringTimeSeries>> getDynamicSimulationTimeLineResult(@Parameter(description = "study UUID") @PathVariable("studyUuid") UUID studyUuid,
                                                                              @Parameter(description = "nodeUuid") @PathVariable("nodeUuid") UUID nodeUuid) {
         List<StringTimeSeries> result = studyService.getDynamicSimulationTimeLine(nodeUuid);
-        return result != null ? ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(result) :
-                ResponseEntity.noContent().build();
+        return CollectionUtils.isEmpty(result) ? ResponseEntity.noContent().build() :
+                ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(result);
     }
 
     @GetMapping(value = "/studies/{studyUuid}/nodes/{nodeUuid}/dynamic-simulation/status")
     @Operation(summary = "Get the status of dynamic simulation result on study")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "The status of dynamic simulation result"),
-        @ApiResponse(responseCode = "204", description = "No dynamic simulation has been done yet"),
+        @ApiResponse(responseCode = "204", description = "No dynamic simulation status"),
         @ApiResponse(responseCode = "404", description = "The dynamic simulation has not been found")})
     public ResponseEntity<DynamicSimulationStatus> getDynamicSimulationStatus(@Parameter(description = "study UUID") @PathVariable("studyUuid") UUID studyUuid,
                                                              @Parameter(description = "nodeUuid") @PathVariable("nodeUuid") UUID nodeUuid) {

--- a/src/main/java/org/gridsuite/study/server/service/client/timeseries/impl/TimeSeriesClientImpl.java
+++ b/src/main/java/org/gridsuite/study/server/service/client/timeseries/impl/TimeSeriesClientImpl.java
@@ -8,6 +8,7 @@
 package org.gridsuite.study.server.service.client.timeseries.impl;
 
 import com.powsybl.timeseries.TimeSeries;
+import org.apache.commons.lang3.StringUtils;
 import org.gridsuite.study.server.RemoteServicesProperties;
 import org.gridsuite.study.server.dto.timeseries.rest.TimeSeriesGroupRest;
 import org.gridsuite.study.server.service.client.AbstractRestClient;
@@ -17,6 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -50,9 +52,12 @@ public class TimeSeriesClientImpl extends AbstractRestClient implements TimeSeri
 
         // call time-series Rest API
         var timeSeriesJson = getRestTemplate().getForObject(uriComponents.toUriString(), String.class);
-        // convert timeseries to json
-        var timeSeriesObj = TimeSeries.parseJson(timeSeriesJson);
-        return timeSeriesObj;
+        if (!StringUtils.isBlank(timeSeriesJson)) {
+            // convert timeseries to json
+            return TimeSeries.parseJson(timeSeriesJson);
+        } else {
+            return Collections.emptyList();
+        }
     }
 
     @Override

--- a/src/main/java/org/gridsuite/study/server/service/client/timeseries/impl/TimeSeriesClientImpl.java
+++ b/src/main/java/org/gridsuite/study/server/service/client/timeseries/impl/TimeSeriesClientImpl.java
@@ -15,6 +15,7 @@ import org.gridsuite.study.server.service.client.AbstractRestClient;
 import org.gridsuite.study.server.service.client.timeseries.TimeSeriesClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -44,7 +45,7 @@ public class TimeSeriesClientImpl extends AbstractRestClient implements TimeSeri
         String endPointUrl = buildEndPointUrl(getBaseUri(), API_VERSION, TIME_SERIES_END_POINT);
 
         UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.fromHttpUrl(endPointUrl + "{uuid}");
-        if (timeSeriesNames != null && !timeSeriesNames.isEmpty()) {
+        if (!CollectionUtils.isEmpty(timeSeriesNames)) {
             uriComponentsBuilder.queryParam("timeSeriesNames", timeSeriesNames);
         }
         var uriComponents = uriComponentsBuilder
@@ -53,7 +54,7 @@ public class TimeSeriesClientImpl extends AbstractRestClient implements TimeSeri
         // call time-series Rest API
         var timeSeriesJson = getRestTemplate().getForObject(uriComponents.toUriString(), String.class);
         if (!StringUtils.isBlank(timeSeriesJson)) {
-            // convert timeseries to json
+            // convert json to TimeSeries
             return TimeSeries.parseJson(timeSeriesJson);
         } else {
             return Collections.emptyList();

--- a/src/main/java/org/gridsuite/study/server/service/dynamicsimulation/impl/DynamicSimulationServiceImpl.java
+++ b/src/main/java/org/gridsuite/study/server/service/dynamicsimulation/impl/DynamicSimulationServiceImpl.java
@@ -82,7 +82,7 @@ public class DynamicSimulationServiceImpl implements DynamicSimulationService {
 
     @Override
     public List<DoubleTimeSeries> getTimeSeriesResult(UUID nodeUuid, List<String> timeSeriesNames) {
-        List<TimeSeries<?,?>> timeSeries = new ArrayList<>();
+        List<TimeSeries<?, ?>> timeSeries = new ArrayList<>();
 
         Optional<UUID> resultUuidOpt = networkModificationTreeService.getComputationResultUuid(nodeUuid, ComputationType.DYNAMIC_SIMULATION);
 
@@ -108,7 +108,7 @@ public class DynamicSimulationServiceImpl implements DynamicSimulationService {
 
     @Override
     public List<StringTimeSeries> getTimeLineResult(UUID nodeUuid) {
-        List<TimeSeries<?,?>> timeLines = new ArrayList<>();
+        List<TimeSeries<?, ?>> timeLines = new ArrayList<>();
 
         Optional<UUID> resultUuidOpt = networkModificationTreeService.getComputationResultUuid(nodeUuid, ComputationType.DYNAMIC_SIMULATION);
 

--- a/src/main/java/org/gridsuite/study/server/service/dynamicsimulation/impl/DynamicSimulationServiceImpl.java
+++ b/src/main/java/org/gridsuite/study/server/service/dynamicsimulation/impl/DynamicSimulationServiceImpl.java
@@ -126,7 +126,7 @@ public class DynamicSimulationServiceImpl implements DynamicSimulationService {
                 timeLines = timeSeriesClient.getTimeSeriesGroup(timeLineUuid, null);
 
                 // get first element to check type
-                if (CollectionUtils.isEmpty(timeLines) &&
+                if (!CollectionUtils.isEmpty(timeLines) &&
                     !(timeLines.get(0) instanceof StringTimeSeries)) {
                     throw new StudyException(StudyException.Type.TIME_SERIES_BAD_TYPE, "Time lines can not be a type: "
                        + timeLines.get(0).getClass().getSimpleName()

--- a/src/main/java/org/gridsuite/study/server/service/dynamicsimulation/impl/DynamicSimulationServiceImpl.java
+++ b/src/main/java/org/gridsuite/study/server/service/dynamicsimulation/impl/DynamicSimulationServiceImpl.java
@@ -82,7 +82,7 @@ public class DynamicSimulationServiceImpl implements DynamicSimulationService {
 
     @Override
     public List<DoubleTimeSeries> getTimeSeriesResult(UUID nodeUuid, List<String> timeSeriesNames) {
-        List<TimeSeries> timeSeries = new ArrayList<>();
+        List<TimeSeries<?,?>> timeSeries = new ArrayList<>();
 
         Optional<UUID> resultUuidOpt = networkModificationTreeService.getComputationResultUuid(nodeUuid, ComputationType.DYNAMIC_SIMULATION);
 
@@ -90,7 +90,7 @@ public class DynamicSimulationServiceImpl implements DynamicSimulationService {
             UUID timeSeriesUuid = dynamicSimulationClient.getTimeSeriesResult(resultUuidOpt.get()); // get timeseries uuid
             if (timeSeriesUuid != null) {
                 // get timeseries data
-                timeSeries = timeSeriesClient.getTimeSeriesGroup(timeSeriesUuid, timeSeriesNames);
+                timeSeries = (List) timeSeriesClient.getTimeSeriesGroup(timeSeriesUuid, timeSeriesNames);
 
                 // get first element to check type
                 if (timeSeries != null &&
@@ -108,7 +108,7 @@ public class DynamicSimulationServiceImpl implements DynamicSimulationService {
 
     @Override
     public List<StringTimeSeries> getTimeLineResult(UUID nodeUuid) {
-        List<TimeSeries> timeLines = new ArrayList<>();
+        List<TimeSeries<?,?>> timeLines = new ArrayList<>();
 
         Optional<UUID> resultUuidOpt = networkModificationTreeService.getComputationResultUuid(nodeUuid, ComputationType.DYNAMIC_SIMULATION);
 
@@ -116,7 +116,7 @@ public class DynamicSimulationServiceImpl implements DynamicSimulationService {
             UUID timeLineUuid = dynamicSimulationClient.getTimeLineResult(resultUuidOpt.get()); // get timeline uuid
             if (timeLineUuid != null) {
                 // get timeline data
-                timeLines = timeSeriesClient.getTimeSeriesGroup(timeLineUuid, null);
+                timeLines = (List) timeSeriesClient.getTimeSeriesGroup(timeLineUuid, null);
 
                 // get first element to check type
                 if (timeLines != null &&

--- a/src/test/java/org/gridsuite/study/server/service/client/timeseries/TimeSeriesClientTest.java
+++ b/src/test/java/org/gridsuite/study/server/service/client/timeseries/TimeSeriesClientTest.java
@@ -17,6 +17,7 @@ import jakarta.validation.constraints.NotNull;
 import okhttp3.mockwebserver.Dispatcher;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.RecordedRequest;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.gridsuite.study.server.RemoteServicesProperties;
 import org.gridsuite.study.server.dto.timeseries.rest.TimeSeriesGroupRest;
@@ -47,6 +48,7 @@ public class TimeSeriesClientTest extends AbstractRestClientTest {
 
     public static final String TIME_SERIES_NAME_1 = "NETWORK__BUS____2-BUS____5-1_AC_iSide2";
     public static final String TIME_SERIES_NAME_2 = "NETWORK__BUS____1_TN_Upu_value";
+    public static final String TIME_SERIES_NAME_UNKNOWN = "TIME_SERIES_NAME_UNKNOWN";
     public static final String TIME_LINE_NAME = "TimeLine";
 
     private final Map<String, List<TimeSeries>> database = new HashMap<>();
@@ -110,7 +112,7 @@ public class TimeSeriesClientTest extends AbstractRestClientTest {
                             timeseries = database.get(groupUuid).stream().filter(series -> timeSeriesNames.contains(series.getMetadata().getName())).collect(Collectors.toList());
                         }
 
-                        if (timeseries == null) {
+                        if (CollectionUtils.isEmpty(timeseries)) {
                             return new MockResponse().setResponseCode(HttpStatus.NO_CONTENT.value());
                         }
 
@@ -189,6 +191,7 @@ public class TimeSeriesClientTest extends AbstractRestClientTest {
     @Test
     public void testGetTimeSeriesGroupGivenTimeSeriesNames() throws JsonProcessingException {
         List<TimeSeries> timeSeries = timeSeriesClient.getTimeSeriesGroup(UUID.fromString(TIME_SERIES_GROUP_UUID), List.of(TIME_SERIES_NAME_1));
+        List<TimeSeries> timeSeriesNameUnknown = timeSeriesClient.getTimeSeriesGroup(UUID.fromString(TIME_SERIES_GROUP_UUID), List.of(TIME_SERIES_NAME_UNKNOWN));
         List<TimeSeries> timeLines = timeSeriesClient.getTimeSeriesGroup(UUID.fromString(TIME_LINE_GROUP_UUID), List.of(TIME_LINE_NAME));
 
         // --- check result --- //
@@ -202,6 +205,11 @@ public class TimeSeriesClientTest extends AbstractRestClientTest {
         String resultTimeSeriesJson = TimeSeries.toJson(timeSeries);
         getLogger().info("resultTimeSeriesJson = " + resultTimeSeriesJson);
         assertEquals(objectMapper.readTree(expectedTimeSeriesJson), objectMapper.readTree(resultTimeSeriesJson));
+
+        // check time series unknown
+        // must contain only zero element
+        getLogger().info("Timeseries size = " + timeSeriesNameUnknown.size());
+        assertEquals(0, timeSeriesNameUnknown.size());
 
         // check timeline
         // must contain only one element


### PR DESCRIPTION
**Correction in this PR:**

1. When timeseries uuid is empty, do not send request to time-series-server

**Related PRs:**

GridStudy-app : https://github.com/gridsuite/gridstudy-app/pull/1870 (with demo)
Dynamic-simulation-server : https://github.com/gridsuite/dynamic-simulation-server/pull/86
