### PR TITLE
WIP : adds secondary sorts param to the shortcircuit result request

### DIFF
--- a/src/main/java/org/gridsuite/study/server/StudyController.java
+++ b/src/main/java/org/gridsuite/study/server/StudyController.java
@@ -660,8 +660,8 @@ public class StudyController {
                                                             "NONE (no fault)") @RequestParam(name = "mode", required = false, defaultValue = "FULL") FaultResultsMode mode,
                                                         @Parameter(description = "type") @RequestParam(value = "type", required = false, defaultValue = "ALL_BUSES") ShortcircuitAnalysisType type,
                                                         @Parameter(description = "JSON array of filters") @RequestParam(name = "filters", required = false) String filters,
-                                                        @Parameter(description = "secSortKey") @RequestParam(name = "sec_sort_key", defaultValue = "") String secSortKey,
-                                                        @Parameter(description = "secSortDirection") @RequestParam(name = "sec_sort_dir", required = false) String secSortDirection,
+                                                        @Parameter(description = "key of the secondary sort") @RequestParam(name = "sec_sort_key", defaultValue = "") String secSortKey,
+                                                        @Parameter(description = "direction of the secondary sort") @RequestParam(name = "sec_sort_dir", required = false) String secSortDirection,
                                                         @Parameter(description = "If we wanted the paged version of the results or not") @RequestParam(name = "paged", required = false) boolean paged,
                                                         Pageable pageable) {
         // parse to get secondary sorting :

--- a/src/main/java/org/gridsuite/study/server/StudyController.java
+++ b/src/main/java/org/gridsuite/study/server/StudyController.java
@@ -40,6 +40,7 @@ import org.gridsuite.study.server.service.shortcircuit.FaultResultsMode;
 import org.gridsuite.study.server.service.shortcircuit.ShortCircuitService;
 import org.gridsuite.study.server.service.shortcircuit.ShortcircuitAnalysisType;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.util.Pair;
 import org.springframework.http.*;
 import org.springframework.util.CollectionUtils;
@@ -659,9 +660,16 @@ public class StudyController {
                                                             "NONE (no fault)") @RequestParam(name = "mode", required = false, defaultValue = "FULL") FaultResultsMode mode,
                                                         @Parameter(description = "type") @RequestParam(value = "type", required = false, defaultValue = "ALL_BUSES") ShortcircuitAnalysisType type,
                                                         @Parameter(description = "JSON array of filters") @RequestParam(name = "filters", required = false) String filters,
+                                                        @Parameter(description = "secSortKey") @RequestParam(name = "sec_sort_key", defaultValue = "") String secSortKey,
+                                                        @Parameter(description = "secSortDirection") @RequestParam(name = "sec_sort_dir", required = false) String secSortDirection,
                                                         @Parameter(description = "If we wanted the paged version of the results or not") @RequestParam(name = "paged", required = false) boolean paged,
                                                         Pageable pageable) {
-        String result = shortCircuitService.getShortCircuitAnalysisResult(nodeUuid, mode, type, filters, paged, pageable);
+        // parse to get secondary sorting :
+        Sort.Order secSort = null;
+        if (StringUtils.isNotBlank(secSortKey)) {
+            secSort = new Sort.Order(Sort.Direction.fromString(secSortDirection), secSortKey);
+        }
+        String result = shortCircuitService.getShortCircuitAnalysisResult(nodeUuid, mode, type, filters, paged, pageable, secSort);
         return result != null ? ResponseEntity.ok().body(result) :
                 ResponseEntity.noContent().build();
     }

--- a/src/main/java/org/gridsuite/study/server/service/shortcircuit/ShortCircuitService.java
+++ b/src/main/java/org/gridsuite/study/server/service/shortcircuit/ShortCircuitService.java
@@ -28,6 +28,7 @@ import org.gridsuite.study.server.service.NetworkService;
 import org.gridsuite.study.server.service.StudyService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpStatusCodeException;
@@ -145,11 +146,12 @@ public class ShortCircuitService {
         return resultPath + "/paged";
     }
 
-    public String getShortCircuitAnalysisResult(UUID nodeUuid, FaultResultsMode mode, ShortcircuitAnalysisType type, String filters, boolean paged, Pageable pageable) {
+    public String getShortCircuitAnalysisResult(UUID nodeUuid, FaultResultsMode mode, ShortcircuitAnalysisType type,
+                                                String filters, boolean paged, Pageable pageable, Sort.Order secSort) {
         if (paged) {
-            return getShortCircuitAnalysisResultsPage(nodeUuid, mode, type, filters, pageable);
+            return getShortCircuitAnalysisResultsPage(nodeUuid, mode, type, filters, pageable, secSort);
         } else {
-            return getShortCircuitAnalysisResult(nodeUuid, mode, type);
+            return getShortCircuitAnalysisResult(nodeUuid, mode, type, secSort);
         }
     }
 
@@ -184,18 +186,27 @@ public class ShortCircuitService {
         return getShortCircuitAnalysisCsvResultResource(builder.build().toUri(), headersCsv);
     }
 
-    public String getShortCircuitAnalysisResult(UUID nodeUuid, FaultResultsMode mode, ShortcircuitAnalysisType type) {
+    public String getShortCircuitAnalysisResult(UUID nodeUuid, FaultResultsMode mode, ShortcircuitAnalysisType type, Sort.Order secSort) {
         String resultPath = getShortCircuitAnalysisResultResourcePath(nodeUuid, type);
         if (resultPath == null) {
             return null;
         }
         UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(shortCircuitServerBaseUri + resultPath)
                 .queryParam("mode", mode);
+        if (secSort != null) {
+            builder = builder.queryParam("sec_sort_key", secSort.getProperty())
+                    .queryParam("sec_sort_dir", secSort.getDirection());
+        }
 
         return getShortCircuitAnalysisResource(builder.build().toUri());
     }
 
-    public String getShortCircuitAnalysisResultsPage(UUID nodeUuid, FaultResultsMode mode, ShortcircuitAnalysisType type, String filters, Pageable pageable) {
+    public String getShortCircuitAnalysisResultsPage(UUID nodeUuid,
+                                                     FaultResultsMode mode,
+                                                     ShortcircuitAnalysisType type,
+                                                     String filters,
+                                                     Pageable pageable,
+                                                     Sort.Order secSort) {
         String resultsPath = getShortCircuitAnalysisResultsPageResourcePath(nodeUuid, type);
         if (resultsPath == null) {
             return null;
@@ -203,6 +214,10 @@ public class ShortCircuitService {
 
         UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(shortCircuitServerBaseUri + resultsPath)
                 .queryParam("mode", mode);
+        if (secSort != null) {
+            builder = builder.queryParam("sec_sort_key", secSort.getProperty())
+                    .queryParam("sec_sort_dir", secSort.getDirection());
+        }
 
         if (filters != null && !filters.isEmpty()) {
             builder.queryParam("filters", filters);

--- a/src/test/java/org/gridsuite/study/server/ShortCircuitTest.java
+++ b/src/test/java/org/gridsuite/study/server/ShortCircuitTest.java
@@ -221,7 +221,7 @@ public class ShortCircuitTest {
                 } else if (path.matches("/v1/results/" + SHORT_CIRCUIT_ANALYSIS_RESULT_UUID + "\\?mode=FULL")) {
                     return new MockResponse().setResponseCode(200).setBody(SHORT_CIRCUIT_ANALYSIS_RESULT_JSON)
                         .addHeader("Content-Type", "application/json; charset=utf-8");
-                } else if (path.matches("/v1/results/" + SHORT_CIRCUIT_ANALYSIS_RESULT_UUID + "/fault_results/paged" + "\\?mode=FULL&page=0&size=20&sort=id,DESC")) {
+                } else if (path.matches("/v1/results/" + SHORT_CIRCUIT_ANALYSIS_RESULT_UUID + "/fault_results/paged" + "\\?mode=FULL&sec_sort_key=connectableId&sec_sort_dir=ASC&page=0&size=20&sort=id,DESC")) {
                     return new MockResponse().setResponseCode(200).setBody(SHORT_CIRCUIT_ANALYSIS_RESULT_JSON)
                             .addHeader("Content-Type", "application/json; charset=utf-8");
                 } else if (path.matches("/v1/results/" + SHORT_CIRCUIT_ANALYSIS_RESULT_UUID + "/csv")) {
@@ -477,14 +477,17 @@ public class ShortCircuitTest {
         assertTrue(TestUtils.getRequestsDone(1, server).stream().anyMatch(r -> r.matches("/v1/networks/" + NETWORK_UUID_STRING + "/run-and-save\\?receiver=.*&reportUuid=.*&reporterId=.*&variantId=" + VARIANT_ID_2)));
 
         // get short circuit result with pagination
-        mockMvc.perform(get("/v1/studies/{studyUuid}/nodes/{nodeUuid}/shortcircuit/result?paged=true&page=0&size=20&sort=id,DESC", studyNameUserIdUuid, modificationNode1Uuid)).andExpectAll(
+        mockMvc.perform(get("/v1/studies/{studyUuid}/nodes/{nodeUuid}/shortcircuit/result?paged=true&page=0&size=20&sort=id,DESC&sec_sort_key=connectableId&sec_sort_dir=asc",
+                studyNameUserIdUuid, modificationNode1Uuid)).andExpectAll(
                 status().isOk(),
                 content().string(SHORT_CIRCUIT_ANALYSIS_RESULT_JSON));
 
-        assertTrue(TestUtils.getRequestsDone(1, server).stream().anyMatch(r -> r.matches("/v1/results/" + SHORT_CIRCUIT_ANALYSIS_RESULT_UUID + "/fault_results/paged\\?mode=FULL&page=0&size=20&sort=id,DESC")));
+        assertTrue(TestUtils.getRequestsDone(1, server).stream().anyMatch(r -> r.matches("/v1/results/" + SHORT_CIRCUIT_ANALYSIS_RESULT_UUID + "/fault_results/paged\\?mode=FULL&sec_sort_key=connectableId&sec_sort_dir=ASC&page=0&size=20&sort=id,DESC")));
 
         // get short circuit result with pagination but with unknown node
-        mockMvc.perform(get("/v1/studies/{studyUuid}/nodes/{nodeUuid}/shortcircuit/result?paged=true&page=0&size=20", studyNameUserIdUuid, unknownModificationNodeUuid)).andExpect(
+        mockMvc.perform(get("/v1/studies/{studyUuid}/nodes/{nodeUuid}/shortcircuit/result?paged=true&page=0&size=20",
+                studyNameUserIdUuid, unknownModificationNodeUuid))
+                .andExpect(
                 status().isNoContent());
 
         assertTrue(TestUtils.getRequestsDone(0, server).isEmpty());


### PR DESCRIPTION
Those parameters are used in shortcircuit-server. They are transmitted through study-server, nothing else.

=> **this PR will probably not be merged** if the sort is transmitted through the pageable object