### PR TITLE
default error message for Study Creation Error

### DIFF
--- a/src/main/java/org/gridsuite/study/server/notification/NotificationService.java
+++ b/src/main/java/org/gridsuite/study/server/notification/NotificationService.java
@@ -159,6 +159,10 @@ public class NotificationService {
     }
 
     public void emitStudyCreationError(UUID studyUuid, String userId, String errorMessage) {
+        if (errorMessage == null || errorMessage.isEmpty()) {
+            // an error message is needed in order for this message to be interpreted later as an error notification
+            errorMessage = "Unknown error";
+        }
         sendUpdateMessage(MessageBuilder.withPayload("")
                 .setHeader(HEADER_STUDY_UUID, studyUuid)
                 .setHeader(HEADER_USER_ID, userId)

--- a/src/main/java/org/gridsuite/study/server/notification/NotificationService.java
+++ b/src/main/java/org/gridsuite/study/server/notification/NotificationService.java
@@ -159,15 +159,14 @@ public class NotificationService {
     }
 
     public void emitStudyCreationError(UUID studyUuid, String userId, String errorMessage) {
-        if (errorMessage == null || errorMessage.isEmpty()) {
-            // an error message is needed in order for this message to be interpreted later as an error notification
-            errorMessage = "Unknown error";
-        }
         sendUpdateMessage(MessageBuilder.withPayload("")
                 .setHeader(HEADER_STUDY_UUID, studyUuid)
                 .setHeader(HEADER_USER_ID, userId)
                 .setHeader(HEADER_UPDATE_TYPE, UPDATE_TYPE_STUDIES)
-                .setHeader(HEADER_ERROR, errorMessage)
+                // an error message is needed in order for this message to be interpreted later as an error notification
+                .setHeader(HEADER_ERROR, (errorMessage == null || errorMessage.isEmpty()) ?
+                                "Unknown error" :
+                                errorMessage)
                 .build());
     }
 

--- a/src/main/java/org/gridsuite/study/server/notification/NotificationService.java
+++ b/src/main/java/org/gridsuite/study/server/notification/NotificationService.java
@@ -104,6 +104,7 @@ public class NotificationService {
     public static final String SUBTREE_MOVED = "subtreeMoved";
     public static final String SUBTREE_CREATED = "subtreeCreated";
     public static final String MESSAGE_LOG = "Sending message : {}";
+    public static final String DEFAULT_ERROR_MESSAGE = "Unknown error";
 
     public static final String STUDY_ALERT = "STUDY_ALERT";
 
@@ -165,8 +166,8 @@ public class NotificationService {
                 .setHeader(HEADER_UPDATE_TYPE, UPDATE_TYPE_STUDIES)
                 // an error message is needed in order for this message to be interpreted later as an error notification
                 .setHeader(HEADER_ERROR, (errorMessage == null || errorMessage.isEmpty()) ?
-                                "Unknown error" :
-                                errorMessage)
+                        DEFAULT_ERROR_MESSAGE :
+                        errorMessage)
                 .build());
     }
 

--- a/src/test/java/org/gridsuite/study/server/StudyTest.java
+++ b/src/test/java/org/gridsuite/study/server/StudyTest.java
@@ -91,6 +91,7 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMoc
 import static org.gridsuite.study.server.StudyConstants.CASE_API_VERSION;
 import static org.gridsuite.study.server.StudyConstants.HEADER_USER_ID;
 import static org.gridsuite.study.server.StudyException.Type.STUDY_NOT_FOUND;
+import static org.gridsuite.study.server.notification.NotificationService.DEFAULT_ERROR_MESSAGE;
 import static org.gridsuite.study.server.utils.MatcherBasicStudyInfos.createMatcherStudyBasicInfos;
 import static org.gridsuite.study.server.utils.MatcherCreatedStudyBasicInfos.createMatcherCreatedStudyBasicInfos;
 import static org.gridsuite.study.server.utils.MatcherStudyInfos.createMatcherStudyInfos;
@@ -157,6 +158,7 @@ public class StudyTest {
     private static final String CASE_3_UUID_STRING = "790769f9-bd31-43be-be46-e50296951e32";
     private static final String CASE_UUID_CAUSING_IMPORT_ERROR = "178719f5-cccc-48be-be46-e92345951e32";
     private static final String CASE_UUID_CAUSING_STUDY_CREATION_ERROR = "278719f5-cccc-48be-be46-e92345951e32";
+    private static final String CASE_UUID_CAUSING_CONVERSION_ERROR = "278719f5-cccc-48be-be46-e92345951e33";
     private static final String NETWORK_UUID_2_STRING = "11111111-aaaa-48be-be46-ef7b93331e32";
     private static final String NETWORK_UUID_3_STRING = "22222222-bd31-43be-be46-e50296951e32";
     private static final NetworkInfos NETWORK_INFOS_2 = new NetworkInfos(UUID.fromString(NETWORK_UUID_2_STRING), "file_2.xiidm");
@@ -453,6 +455,10 @@ public class StudyTest {
                     sendCaseImportFailedMessage(path, STUDY_CREATION_ERROR_MESSAGE);
                     return new MockResponse().setResponseCode(200)
                         .addHeader("Content-Type", "application/json; charset=utf-8");
+                } else if (path.matches("/v1/networks\\?caseUuid=" + CASE_UUID_CAUSING_CONVERSION_ERROR + "&variantId=" + FIRST_VARIANT_ID + "&reportUuid=.*&receiver=.*")) {
+                    sendCaseImportFailedMessage(path, null); // some conversion errors don't returnany error mesage
+                    return new MockResponse().setResponseCode(200)
+                        .addHeader("Content-Type", "application/json; charset=utf-8");
                 } else if (path.matches("/v1/reports/.*")) {
                     return new MockResponse().setResponseCode(200).setBody(mapper.writeValueAsString(ROOT_REPORT_TEST.getSubReporters()))
                         .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
@@ -519,6 +525,9 @@ public class StudyTest {
                     case "/v1/cases/" + CASE_3_UUID_STRING + "/exists":
                     case "/v1/cases/" + CASE_UUID_CAUSING_IMPORT_ERROR + "/exists":
                     case "/v1/cases/" + CASE_UUID_CAUSING_STUDY_CREATION_ERROR + "/exists":
+                        return new MockResponse().setResponseCode(200).setBody("true")
+                            .addHeader("Content-Type", "application/json; charset=utf-8");
+                    case "/v1/cases/" + CASE_UUID_CAUSING_CONVERSION_ERROR + "/exists":
                         return new MockResponse().setResponseCode(200).setBody("true")
                             .addHeader("Content-Type", "application/json; charset=utf-8");
                     case "/v1/cases/" + CASE_UUID_STRING + "/infos":
@@ -1167,6 +1176,30 @@ public class StudyTest {
         var requests = TestUtils.getRequestsDone(2, server);
         assertTrue(requests.contains(String.format("/v1/cases/%s/exists", CASE_UUID_CAUSING_IMPORT_ERROR)));
         assertTrue(requests.stream().anyMatch(r -> r.matches("/v1/networks\\?caseUuid=" + CASE_UUID_CAUSING_IMPORT_ERROR + "&variantId=" + FIRST_VARIANT_ID + "&reportUuid=.*")));
+    }
+
+    @Test
+    public void testCreateStudyCreationFailedWithoutErrorMessage() throws Exception {
+        String userId = "userId";
+        mockMvc.perform(post("/v1/studies/cases/{caseUuid}", CASE_UUID_CAUSING_CONVERSION_ERROR)
+                        .header("userId", userId)
+                        .param(CASE_FORMAT, "XIIDM"))
+                .andExpect(status().isOk());
+
+        // assert that the broker message has been sent a study creation request message
+        Message<byte[]> message = output.receive(TIMEOUT, "study.update");
+        MessageHeaders headers = message.getHeaders();
+        assertEquals(userId, headers.get(HEADER_USER_ID));
+        assertEquals(NotificationService.UPDATE_TYPE_STUDIES, headers.get(HEADER_UPDATE_TYPE));
+
+        // checks that the error message has a default value set
+        message = output.receive(TIMEOUT, "study.update");
+        headers = message.getHeaders();
+        assertEquals(userId, headers.get(HEADER_USER_ID));
+        assertEquals(NotificationService.UPDATE_TYPE_STUDIES, headers.get(HEADER_UPDATE_TYPE));
+        assertEquals(DEFAULT_ERROR_MESSAGE, headers.get(NotificationService.HEADER_ERROR));
+
+        TestUtils.getRequestsDone(2, server);
     }
 
     @Test


### PR DESCRIPTION
Some error (like in the conversion-server) don't return any error message. But during the message handling in directory-server and gridexplore those notification need an error message in order to interpret those notification as errors and act accordingly.

A simple default "Unknown error" is aded for those cases.

NOTE : new error notifcation types could be added for a cleaner code, but it would mean too much change for now.