### PR TITLE
delete orphaned indexed equipments

### DIFF
--- a/src/main/java/org/gridsuite/study/server/StudyController.java
+++ b/src/main/java/org/gridsuite/study/server/StudyController.java
@@ -119,6 +119,21 @@ public class StudyController {
         return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(studyService.getStudies());
     }
 
+    @GetMapping(value = "/orphan_indexed_equipments_count")
+    @Operation(summary = "Get all orphan indexed equipments count")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "The count of orphan indexed equipments")})
+    public ResponseEntity<Long> getOrphanIndexedEquipmentsCount() {
+        return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(studyService.getAllOrphanIndexedEquipmentsCount());
+    }
+
+    @DeleteMapping(value = "/orphan_indexed_equipments")
+    @Operation(summary = "Delete all orphan indexed equipments")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "All orphan indexed equipments have been deleted")})
+    public ResponseEntity<Void> deleteOrphanIndexedEquipments() {
+        studyService.deleteAllOrphanIndexedEquipments();
+        return ResponseEntity.ok().build();
+    }
+
     @GetMapping(value = "/studies/{studyUuid}/case/name")
     @Operation(summary = "Get study case name")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "The study case name"),

--- a/src/main/java/org/gridsuite/study/server/elasticsearch/EquipmentInfosRepository.java
+++ b/src/main/java/org/gridsuite/study/server/elasticsearch/EquipmentInfosRepository.java
@@ -12,6 +12,7 @@ import org.springframework.lang.NonNull;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 /**
  * @author Slimane Amar <slimane.amar at rte-france.com>
@@ -24,4 +25,9 @@ public interface EquipmentInfosRepository extends ElasticsearchRepository<Equipm
     void deleteAllByNetworkUuidAndVariantId(@NonNull UUID networkUuid, @NonNull String variantId);
 
     long countByNetworkUuid(@NonNull UUID networkUuid);
+
+    Stream<EquipmentInfos> findByNetworkUuidNotIn(List<UUID> networkUuids);
+
+    long countByNetworkUuidNotIn(List<UUID> networkUuids);
+
 }

--- a/src/main/java/org/gridsuite/study/server/elasticsearch/TombstonedEquipmentInfosRepository.java
+++ b/src/main/java/org/gridsuite/study/server/elasticsearch/TombstonedEquipmentInfosRepository.java
@@ -12,6 +12,7 @@ import org.springframework.lang.NonNull;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 /**
  * @author Nicolas Noir <nicolas.noir at rte-france.com>
@@ -19,9 +20,13 @@ import java.util.UUID;
 public interface TombstonedEquipmentInfosRepository extends ElasticsearchRepository<TombstonedEquipmentInfos, String> {
     List<TombstonedEquipmentInfos> findAllByNetworkUuid(@NonNull UUID networkUuid);
 
+    Stream<TombstonedEquipmentInfos> findByNetworkUuidNotIn(List<UUID> networkUuids);
+
     void deleteAllByNetworkUuid(@NonNull UUID networkUuid);
 
     void deleteAllByNetworkUuidAndVariantId(@NonNull UUID networkUuid, @NonNull String variantId);
 
     long countByNetworkUuid(@NonNull UUID networkUuid);
+
+    long countByNetworkUuidNotIn(List<UUID> networkUuids);
 }

--- a/src/main/java/org/gridsuite/study/server/service/StudyService.java
+++ b/src/main/java/org/gridsuite/study/server/service/StudyService.java
@@ -238,6 +238,24 @@ public class StudyService {
                 .collect(Collectors.toList());
     }
 
+    public List<UUID> getStudiesNetworkUuids() {
+        return studyRepository.findAll().stream()
+                .map(StudyEntity::getNetworkUuid)
+                .toList();
+    }
+
+    public void deleteAllOrphanIndexedEquipments() {
+        var studiesNetworkUuids = getStudiesNetworkUuids();
+        equipmentInfosService.deleteAllByNetworkUuidNotIn(studiesNetworkUuids);
+        equipmentInfosService.deleteAllTombstonedEquipmentsByNetworkUuidNotIn(studiesNetworkUuids);
+    }
+
+    public Long getAllOrphanIndexedEquipmentsCount() {
+        Long orphanEquipmentsCount = equipmentInfosService.getEquipmentInfosCountNotIn(getStudiesNetworkUuids());
+        Long orphanTombstonedEquipmentsCount = equipmentInfosService.getTombstonedEquipmentInfosCountNotIn(getStudiesNetworkUuids());
+        return orphanEquipmentsCount + orphanTombstonedEquipmentsCount;
+    }
+
     public String getStudyCaseName(UUID studyUuid) {
         Objects.requireNonNull(studyUuid);
         StudyEntity study = studyRepository.findById(studyUuid).orElseThrow(() -> new StudyException(STUDY_NOT_FOUND));


### PR DESCRIPTION
This pull request implement the process of deleting orphan indexed equipments from Elasticsearch. The goal is to ensure that equipments whose networkUuid is no longer present in the database are efficiently deleted. 