### PR TITLE
Fix node and subtree restoration

### DIFF
--- a/src/main/java/org/gridsuite/study/server/repository/networkmodificationtree/NodeRepository.java
+++ b/src/main/java/org/gridsuite/study/server/repository/networkmodificationtree/NodeRepository.java
@@ -20,6 +20,8 @@ import java.util.UUID;
  * @author Jacques Borsenberger <jacques.borsenberger at rte-france.com>
  */
 public interface NodeRepository extends JpaRepository<NodeEntity, UUID> {
+    long countByParentNodeIdNode(UUID id);
+
     List<NodeEntity> findAllByParentNodeIdNode(UUID id);
 
     List<NodeEntity> findAllByStudyId(UUID id);

--- a/src/main/java/org/gridsuite/study/server/service/NetworkModificationTreeService.java
+++ b/src/main/java/org/gridsuite/study/server/service/NetworkModificationTreeService.java
@@ -590,8 +590,13 @@ public class NetworkModificationTreeService {
             nodeToRestore.setStashed(false);
             nodeToRestore.setStashDate(null);
             nodesRepository.save(nodeToRestore);
-            notificationService.emitNodeInserted(studyId, anchorNodeId, nodeId, InsertMode.AFTER, anchorNodeId);
-            restoreNodeChildren(studyId, nodeId);
+            boolean hasChildren = nodesRepository.countByParentNodeIdNode(nodeId) > 0;
+            if (hasChildren) {
+                restoreNodeChildren(studyId, nodeId);
+                notificationService.emitSubtreeInserted(studyId, nodeId, anchorNodeId);
+            } else {
+                notificationService.emitNodeInserted(studyId, anchorNodeId, nodeId, InsertMode.CHILD, anchorNodeId);
+            }
         }
     }
 
@@ -626,7 +631,6 @@ public class NetworkModificationTreeService {
             nodeEntity.setStashed(false);
             nodeEntity.setStashDate(null);
             nodesRepository.save(nodeEntity);
-            notificationService.emitNodeInserted(studyId, parentNodeId, nodeEntity.getIdNode(), InsertMode.AFTER, parentNodeId);
             restoreNodeChildren(studyId, nodeEntity.getIdNode());
         });
     }

--- a/src/main/java/org/gridsuite/study/server/service/NetworkModificationTreeService.java
+++ b/src/main/java/org/gridsuite/study/server/service/NetworkModificationTreeService.java
@@ -590,14 +590,17 @@ public class NetworkModificationTreeService {
             nodeToRestore.setStashed(false);
             nodeToRestore.setStashDate(null);
             nodesRepository.save(nodeToRestore);
-            boolean hasChildren = nodesRepository.countByParentNodeIdNode(nodeId) > 0;
-            if (hasChildren) {
+            if (hasChildren(nodeId)) {
                 restoreNodeChildren(studyId, nodeId);
                 notificationService.emitSubtreeInserted(studyId, nodeId, anchorNodeId);
             } else {
                 notificationService.emitNodeInserted(studyId, anchorNodeId, nodeId, InsertMode.CHILD, anchorNodeId);
             }
         }
+    }
+
+    private boolean hasChildren(UUID nodeId) {
+        return nodesRepository.countByParentNodeIdNode(nodeId) > 0;
     }
 
     @Transactional

--- a/src/test/java/org/gridsuite/study/server/NetworkModificationTreeTest.java
+++ b/src/test/java/org/gridsuite/study/server/NetworkModificationTreeTest.java
@@ -725,15 +725,15 @@ class NetworkModificationTreeTest {
                 assertTrue(expectedStash.stream().anyMatch(node -> node.getId().equals(id))));
     }
 
-    private void restoreNode(UUID studyUuid, List<UUID> nodeId, UUID anchorNodeId, String userId) throws Exception {
-        String param = nodeId.stream().map(UUID::toString).reduce("", (a1, a2) -> a1 + "," + a2).substring(1);
+    private void restoreNode(UUID studyUuid, List<UUID> nodeIds, UUID anchorNodeId, String userId) throws Exception {
+        String param = nodeIds.stream().map(UUID::toString).reduce("", (a1, a2) -> a1 + "," + a2).substring(1);
         mockMvc.perform(post("/v1/studies/{studyUuid}/tree/nodes/restore?anchorNodeId={anchorNodeId}", studyUuid, anchorNodeId).header(USER_ID_HEADER, userId)
                         .queryParam("ids", param))
                 .andExpect(status().isOk());
 
-        for (int i = 0; i < nodeId.size(); i++) {
+        for (int i = 0; i < nodeIds.size(); i++) {
             var message = output.receive(TIMEOUT, STUDY_UPDATE_DESTINATION);
-            assertTrue(nodeId.contains(message.getHeaders().get(HEADER_NEW_NODE)) || anchorNodeId.equals(message.getHeaders().get(HEADER_NEW_NODE)));
+            assertTrue(nodeIds.contains(message.getHeaders().get(HEADER_NEW_NODE)) || anchorNodeId.equals(message.getHeaders().get(HEADER_NEW_NODE)));
         }
     }
 


### PR DESCRIPTION
fix(): When restoring a subtree, do not send a `nodeCreated` notifica…tion for each nodes in the subtree but a single notification to `insertSubtree` and all its children.

fix(): RestoreNode now use the `InsertMode.CHILD` to add a new branch instead of trying to insert a node between the parent and already existing children. It causes unexpected behaviors.