### PR TITLE
Fix supervision endpoints error with root networks in creation

### DIFF
--- a/src/main/java/org/gridsuite/study/server/StudyController.java
+++ b/src/main/java/org/gridsuite/study/server/StudyController.java
@@ -182,7 +182,7 @@ public class StudyController {
     @Operation(summary = "Get root networks for study")
     @ApiResponse(responseCode = "200", description = "List of root networks")
     public ResponseEntity<List<BasicRootNetworkInfos>> getRootNetworks(@PathVariable("studyUuid") UUID studyUuid) {
-        return ResponseEntity.ok().body(studyService.getBasicRootNetworkInfos(studyUuid));
+        return ResponseEntity.ok().body(studyService.getAllBasicRootNetworkInfos(studyUuid));
     }
 
     @PostMapping(value = "/studies/{studyUuid}/root-networks")

--- a/src/main/java/org/gridsuite/study/server/service/StudyService.java
+++ b/src/main/java/org/gridsuite/study/server/service/StudyService.java
@@ -2503,17 +2503,21 @@ public class StudyService {
         return rootNetworkEntities.stream().map(RootNetworkEntity::toDto).toList();
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public List<BasicRootNetworkInfos> getAllBasicRootNetworkInfos(UUID studyUuid) {
         return Stream
             .concat(
-                getStudyRootNetworks(studyUuid).stream().map(RootNetworkEntity::toBasicDto),
+                getExistingRootNetworkInfos(studyUuid).stream(),
                 rootNetworkService.getCreationRequests(studyUuid).stream().map(RootNetworkCreationRequestEntity::toBasicDto))
             .toList();
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public List<BasicRootNetworkInfos> getExistingBasicRootNetworkInfos(UUID studyUuid) {
+        return getExistingRootNetworkInfos(studyUuid);
+    }
+
+    private List<BasicRootNetworkInfos> getExistingRootNetworkInfos(UUID studyUuid) {
         return getStudyRootNetworks(studyUuid).stream().map(RootNetworkEntity::toBasicDto).toList();
     }
 

--- a/src/main/java/org/gridsuite/study/server/service/StudyService.java
+++ b/src/main/java/org/gridsuite/study/server/service/StudyService.java
@@ -2504,12 +2504,17 @@ public class StudyService {
     }
 
     @Transactional
-    public List<BasicRootNetworkInfos> getBasicRootNetworkInfos(UUID studyUuid) {
+    public List<BasicRootNetworkInfos> getAllBasicRootNetworkInfos(UUID studyUuid) {
         return Stream
             .concat(
                 getStudyRootNetworks(studyUuid).stream().map(RootNetworkEntity::toBasicDto),
                 rootNetworkService.getCreationRequests(studyUuid).stream().map(RootNetworkCreationRequestEntity::toBasicDto))
             .toList();
+    }
+
+    @Transactional
+    public List<BasicRootNetworkInfos> getExistingBasicRootNetworkInfos(UUID studyUuid) {
+        return getStudyRootNetworks(studyUuid).stream().map(RootNetworkEntity::toBasicDto).toList();
     }
 
     //TODO: temporary method, once frontend had been implemented, each operation will need to target a specific rootNetwork UUID, here we manually target the first one

--- a/src/main/java/org/gridsuite/study/server/service/SupervisionService.java
+++ b/src/main/java/org/gridsuite/study/server/service/SupervisionService.java
@@ -140,7 +140,7 @@ public class SupervisionService {
 
         AtomicReference<Long> nbIndexesToDelete = new AtomicReference<>(0L);
 
-        studyService.getBasicRootNetworkInfos(studyUuid).forEach(rootNetwork -> {
+        studyService.getExistingBasicRootNetworkInfos(studyUuid).forEach(rootNetwork -> {
             UUID networkUUID = rootNetworkService.getNetworkUuid(rootNetwork.rootNetworkUuid());
             nbIndexesToDelete.updateAndGet(v -> v + getStudyIndexedEquipmentsCount(networkUUID) + getStudyIndexedTombstonedEquipmentsCount(networkUUID));
             equipmentInfosService.deleteAllByNetworkUuid(networkUUID);
@@ -306,7 +306,7 @@ public class SupervisionService {
         startTime.set(System.nanoTime());
         UUID rootNodeUuid = networkModificationTreeService.getStudyRootNodeUuid(studyUuid);
         //TODO: to parallelize ?
-        studyService.getBasicRootNetworkInfos(studyUuid).forEach(rootNetwork ->
+        studyService.getExistingBasicRootNetworkInfos(studyUuid).forEach(rootNetwork ->
             studyService.invalidateBuild(studyUuid, rootNodeUuid, rootNetwork.rootNetworkUuid(), false, false, true)
         );
 

--- a/src/test/java/org/gridsuite/study/server/RootNetworkTest.java
+++ b/src/test/java/org/gridsuite/study/server/RootNetworkTest.java
@@ -428,7 +428,7 @@ class RootNetworkTest {
             .build());
 
         // before deletion, check we have 2 root networks for study
-        assertEquals(2, studyService.getAllBasicRootNetworkInfos(studyEntity.getId()).size());
+        assertEquals(2, studyService.getExistingBasicRootNetworkInfos(studyEntity.getId()).size());
 
         mockMvc.perform(delete("/v1/studies/{studyUuid}/root-networks", studyEntity.getId())
                 .contentType(APPLICATION_JSON)
@@ -437,7 +437,7 @@ class RootNetworkTest {
             .andExpect(status().isOk());
 
         // after deletion, check we have only 1 root network for study
-        List<BasicRootNetworkInfos> rootNetworkListAfterDeletion = studyService.getAllBasicRootNetworkInfos(studyEntity.getId());
+        List<BasicRootNetworkInfos> rootNetworkListAfterDeletion = studyService.getExistingBasicRootNetworkInfos(studyEntity.getId());
         assertEquals(1, rootNetworkListAfterDeletion.size());
         assertEquals(firstRootNetworkUuid, rootNetworkListAfterDeletion.get(0).rootNetworkUuid());
 
@@ -477,7 +477,7 @@ class RootNetworkTest {
         studyRepository.save(studyEntity);
 
         networkModificationTreeService.createRoot(studyEntity);
-        UUID firstRootNetworkUuid = studyService.getAllBasicRootNetworkInfos(studyEntity.getId()).get(0).rootNetworkUuid();
+        UUID firstRootNetworkUuid = studyService.getExistingBasicRootNetworkInfos(studyEntity.getId()).get(0).rootNetworkUuid();
 
         // try to delete all root networks
         mockMvc.perform(delete("/v1/studies/{studyUuid}/root-networks", studyEntity.getId())
@@ -486,7 +486,7 @@ class RootNetworkTest {
                 .header("userId", USER_ID))
             .andExpect(status().isForbidden());
 
-        assertEquals(2, studyService.getAllBasicRootNetworkInfos(studyEntity.getId()).size());
+        assertEquals(2, studyService.getExistingBasicRootNetworkInfos(studyEntity.getId()).size());
 
         // try to delete unknown root network
         mockMvc.perform(delete("/v1/studies/{studyUuid}/root-networks", studyEntity.getId())
@@ -495,7 +495,7 @@ class RootNetworkTest {
                 .header("userId", USER_ID))
             .andExpect(status().isNotFound());
 
-        assertEquals(2, studyService.getAllBasicRootNetworkInfos(studyEntity.getId()).size());
+        assertEquals(2, studyService.getExistingBasicRootNetworkInfos(studyEntity.getId()).size());
     }
 
     @Test
@@ -652,7 +652,7 @@ class RootNetworkTest {
         studyRepository.save(studyEntity);
 
         // after creating 3 root networks, check rootNetworkOrder to assert they are correctly incremented
-        List<BasicRootNetworkInfos> result = studyService.getAllBasicRootNetworkInfos(studyEntity.getId());
+        List<BasicRootNetworkInfos> result = studyService.getExistingBasicRootNetworkInfos(studyEntity.getId());
         assertEquals(3, result.size());
         // check rootNetworkOrdered is ordered by creation ordered
         assertEquals("rootNetworkName", result.get(0).name());
@@ -663,7 +663,7 @@ class RootNetworkTest {
         studyService.deleteRootNetworks(studyEntity.getId(), List.of(result.get(1).rootNetworkUuid()), null);
 
         // check "dummyRootNetwork2" root network order have been updated correctly
-        List<BasicRootNetworkInfos> resultAfterDeletion = studyService.getAllBasicRootNetworkInfos(studyEntity.getId());
+        List<BasicRootNetworkInfos> resultAfterDeletion = studyService.getExistingBasicRootNetworkInfos(studyEntity.getId());
         assertEquals(2, resultAfterDeletion.size());
         assertEquals("rootNetworkName", resultAfterDeletion.get(0).name());
         assertEquals("dummyRootNetwork2", resultAfterDeletion.get(1).name());
@@ -680,7 +680,7 @@ class RootNetworkTest {
             .build());
 
         // check "dummyRootNetwork3" root network order have been created correctly
-        List<BasicRootNetworkInfos> resultAfterCreation = studyService.getAllBasicRootNetworkInfos(studyEntity.getId());
+        List<BasicRootNetworkInfos> resultAfterCreation = studyService.getExistingBasicRootNetworkInfos(studyEntity.getId());
         assertEquals(3, resultAfterCreation.size());
         assertEquals("rootNetworkName", resultAfterCreation.get(0).name());
         assertEquals("dummyRootNetwork2", resultAfterCreation.get(1).name());

--- a/src/test/java/org/gridsuite/study/server/RootNetworkTest.java
+++ b/src/test/java/org/gridsuite/study/server/RootNetworkTest.java
@@ -428,7 +428,7 @@ class RootNetworkTest {
             .build());
 
         // before deletion, check we have 2 root networks for study
-        assertEquals(2, studyService.getBasicRootNetworkInfos(studyEntity.getId()).size());
+        assertEquals(2, studyService.getAllBasicRootNetworkInfos(studyEntity.getId()).size());
 
         mockMvc.perform(delete("/v1/studies/{studyUuid}/root-networks", studyEntity.getId())
                 .contentType(APPLICATION_JSON)
@@ -437,7 +437,7 @@ class RootNetworkTest {
             .andExpect(status().isOk());
 
         // after deletion, check we have only 1 root network for study
-        List<BasicRootNetworkInfos> rootNetworkListAfterDeletion = studyService.getBasicRootNetworkInfos(studyEntity.getId());
+        List<BasicRootNetworkInfos> rootNetworkListAfterDeletion = studyService.getAllBasicRootNetworkInfos(studyEntity.getId());
         assertEquals(1, rootNetworkListAfterDeletion.size());
         assertEquals(firstRootNetworkUuid, rootNetworkListAfterDeletion.get(0).rootNetworkUuid());
 
@@ -477,7 +477,7 @@ class RootNetworkTest {
         studyRepository.save(studyEntity);
 
         networkModificationTreeService.createRoot(studyEntity);
-        UUID firstRootNetworkUuid = studyService.getBasicRootNetworkInfos(studyEntity.getId()).get(0).rootNetworkUuid();
+        UUID firstRootNetworkUuid = studyService.getAllBasicRootNetworkInfos(studyEntity.getId()).get(0).rootNetworkUuid();
 
         // try to delete all root networks
         mockMvc.perform(delete("/v1/studies/{studyUuid}/root-networks", studyEntity.getId())
@@ -486,7 +486,7 @@ class RootNetworkTest {
                 .header("userId", USER_ID))
             .andExpect(status().isForbidden());
 
-        assertEquals(2, studyService.getBasicRootNetworkInfos(studyEntity.getId()).size());
+        assertEquals(2, studyService.getAllBasicRootNetworkInfos(studyEntity.getId()).size());
 
         // try to delete unknown root network
         mockMvc.perform(delete("/v1/studies/{studyUuid}/root-networks", studyEntity.getId())
@@ -495,7 +495,7 @@ class RootNetworkTest {
                 .header("userId", USER_ID))
             .andExpect(status().isNotFound());
 
-        assertEquals(2, studyService.getBasicRootNetworkInfos(studyEntity.getId()).size());
+        assertEquals(2, studyService.getAllBasicRootNetworkInfos(studyEntity.getId()).size());
     }
 
     @Test
@@ -652,7 +652,7 @@ class RootNetworkTest {
         studyRepository.save(studyEntity);
 
         // after creating 3 root networks, check rootNetworkOrder to assert they are correctly incremented
-        List<BasicRootNetworkInfos> result = studyService.getBasicRootNetworkInfos(studyEntity.getId());
+        List<BasicRootNetworkInfos> result = studyService.getAllBasicRootNetworkInfos(studyEntity.getId());
         assertEquals(3, result.size());
         // check rootNetworkOrdered is ordered by creation ordered
         assertEquals("rootNetworkName", result.get(0).name());
@@ -663,7 +663,7 @@ class RootNetworkTest {
         studyService.deleteRootNetworks(studyEntity.getId(), List.of(result.get(1).rootNetworkUuid()), null);
 
         // check "dummyRootNetwork2" root network order have been updated correctly
-        List<BasicRootNetworkInfos> resultAfterDeletion = studyService.getBasicRootNetworkInfos(studyEntity.getId());
+        List<BasicRootNetworkInfos> resultAfterDeletion = studyService.getAllBasicRootNetworkInfos(studyEntity.getId());
         assertEquals(2, resultAfterDeletion.size());
         assertEquals("rootNetworkName", resultAfterDeletion.get(0).name());
         assertEquals("dummyRootNetwork2", resultAfterDeletion.get(1).name());
@@ -680,7 +680,7 @@ class RootNetworkTest {
             .build());
 
         // check "dummyRootNetwork3" root network order have been created correctly
-        List<BasicRootNetworkInfos> resultAfterCreation = studyService.getBasicRootNetworkInfos(studyEntity.getId());
+        List<BasicRootNetworkInfos> resultAfterCreation = studyService.getAllBasicRootNetworkInfos(studyEntity.getId());
         assertEquals(3, resultAfterCreation.size());
         assertEquals("rootNetworkName", resultAfterCreation.get(0).name());
         assertEquals("dummyRootNetwork2", resultAfterCreation.get(1).name());


### PR DESCRIPTION
When there are root networks in creation in the table **root_network_creation_request** (we need to investigate why there are some rows that remain here and never get deleted => crash of pod, error on import, etc), we try to invalidate node/delete index on these networks that don't exist yet which throw an error "ROOT_NETWORK_NOT_FOUND" as it does not exist.

In this PR, I propose to use only existing root network for supervision endpoints: to invalidate nodes and delete indexed equipments.
