### PR TITLE
Modification invalidation wasn't working in some cases

### DIFF
--- a/src/test/java/org/gridsuite/study/server/NetworkModificationTest.java
+++ b/src/test/java/org/gridsuite/study/server/NetworkModificationTest.java
@@ -2486,6 +2486,7 @@ class NetworkModificationTest {
         // add this modification to the node => invalidate the LF
         UUID stubPostId = wireMockUtils.stubNetworkModificationPost(mapper.writeValueAsString(new NetworkModificationsResult(List.of(UUID.randomUUID()), List.of(Optional.empty()))));
         Pair<String, List<ModificationApplicationContext>> modificationBody = Pair.of(bodyJson, List.of(rootNetworkNodeInfoService.getNetworkModificationApplicationContext(firstRootNetworkUuid, modificationNode1Uuid, NETWORK_UUID)));
+        UUID deleteModificationIndexStub = wireMockUtils.stubNetworkModificationDeleteIndex();
         mockMvc.perform(post(URI_NETWORK_MODIF, studyNameUserIdUuid, modificationNode1Uuid)
                         .content(bodyJson).contentType(MediaType.APPLICATION_JSON)
                         .header(USER_ID_HEADER, userId))
@@ -2496,6 +2497,7 @@ class NetworkModificationTest {
         checkEquipmentUpdatingFinishedMessagesReceived(studyNameUserIdUuid, modificationNode1Uuid);
         checkElementUpdatedMessageSent(studyNameUserIdUuid, userId);
         wireMockUtils.verifyNetworkModificationPostWithVariant(stubPostId, getModificationContextJsonString(mapper, modificationBody));
+        wireMockUtils.verifyNetworkModificationDeleteIndex(deleteModificationIndexStub);
 
         var requests = TestUtils.getRequestsDone(22, server); // 1 status LF + 2 x 10 computations + 1 report
         List.of(

--- a/src/test/java/org/gridsuite/study/server/StudyTest.java
+++ b/src/test/java/org/gridsuite/study/server/StudyTest.java
@@ -2671,7 +2671,7 @@ class StudyTest {
         });
 
         if (wasBuilt) {
-            wireMockUtils.verifyNetworkModificationDeleteIndex(deleteModificationIndexStub, 1);
+            wireMockUtils.verifyNetworkModificationDeleteIndex(deleteModificationIndexStub, 1 + childCount);
         }
     }
 


### PR DESCRIPTION
If a built node without children was unbuild **not manually**, modifications were not invalidated