### PR TITLE
wip client pool 200/500

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -200,7 +200,6 @@
             <!-- Used by RestTemplate -->
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
-            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.liquibase</groupId>

--- a/src/main/java/org/gridsuite/study/server/StudyApplication.java
+++ b/src/main/java/org/gridsuite/study/server/StudyApplication.java
@@ -6,8 +6,16 @@
  */
 package org.gridsuite.study.server;
 
+import org.apache.hc.client5.http.classic.HttpClient;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.core5.util.Timeout;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
 
 /**
  * @author Abdelsalem Hedhili <abdelsalem.hedhili at rte-france.com>
@@ -18,4 +26,38 @@ public class StudyApplication {
     public static void main(String[] args) {
         SpringApplication.run(StudyApplication.class, args);
     }
+    
+//    @Bean
+//    public HttpClient httpClient() {
+//        PoolingHttpClientConnectionManager connectionManager = 
+//            new PoolingHttpClientConnectionManager();
+//        connectionManager.setMaxTotal(500);
+//        connectionManager.setDefaultMaxPerRoute(200);
+////        RequestConfig requestConfig = RequestConfig.custom()
+////            .setConnectionRequestTimeout(Timeout.ofMilliseconds(properties.getConnectionRequestTimeout()))
+////            .setConnectTimeout(Timeout.ofMilliseconds(properties.getConnectTimeout()))
+////            .setResponseTimeout(Timeout.ofMilliseconds(properties.getResponseTimeout()))
+////            .build();
+// 
+//        return HttpClients.custom()
+//            .setConnectionManager(connectionManager)
+////            .setDefaultRequestConfig(requestConfig)
+//            .build();
+////    }
+//// 
+//    @Bean
+//    public RestTemplate restTemplate(HttpClient httpClient) {
+//        HttpComponentsClientHttpRequestFactory factory = 
+//            new HttpComponentsClientHttpRequestFactory(httpClient);
+//        return new RestTemplate(factory);
+//    }    
+////    @Bean
+//    Consumer<PoolingHttpClientConnectionManagerBuilder> hcclient5PoolCustomizer() {
+//        System.out.println("jon");
+//        return (pooling) -> {
+//            System.out.println("jon2");
+//            pooling.setMaxConnPerRoute(200);
+//            pooling.setMaxConnTotal(500);
+//        };
+//    }
 }


### PR DESCRIPTION
TODO

2025-06-10T20:28:04.308+02:00 ERROR 21116 --- [study-server] [io-5001-exec-18] o.a.c.c.C.[.[.[/].[dispatcherServlet]    : Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed: java.lang.NullPointerException: Cannot invoke "org.apache.hc.client5.http.io.ManagedHttpClientConnection.isConsistent()" because "conn" is null] with root cause
java.lang.NullPointerException: Cannot invoke "org.apache.hc.client5.http.io.ManagedHttpClientConnection.isConsistent()" because "conn" is null
	at org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager.release(PoolingHttpClientConnectionManager.java:412) ~[httpclient5-5.3.jar!/:5.3]
	at org.apache.hc.client5.http.impl.classic.InternalExecRuntime.discardEndpoint(InternalExecRuntime.java:246) ~[httpclient5-5.3.jar!/:5.3]
	at org.apache.hc.client5.http.impl.classic.InternalExecRuntime.releaseEndpoint(InternalExecRuntime.java:260) ~[httpclient5-5.3.jar!/:5.3]
	at org.apache.hc.client5.http.impl.classic.ResponseEntityProxy.releaseConnection(ResponseEntityProxy.java:80) ~[httpclient5-5.3.jar!/:5.3]
	at org.apache.hc.client5.http.impl.classic.ResponseEntityProxy.eofDetected(ResponseEntityProxy.java:115) ~[httpclient5-5.3.jar!/:5.3]
	at org.apache.hc.core5.http.io.EofSensorInputStream.checkEOF(EofSensorInputStream.java:199) ~[httpcore5-5.2.5.jar!/:5.2.5]
	at org.apache.hc.core5.http.io.EofSensorInputStream.read(EofSensorInputStream.java:136) ~[httpcore5-5.2.5.jar!/:5.2.5]
	at java.base/java.io.InputStream.readNBytes(InputStream.java:412) ~[na:na]
	at java.base/java.io.InputStream.readAllBytes(InputStream.java:349) ~[na:na]
	at org.springframework.util.FileCopyUtils.copyToByteArray(FileCopyUtils.java:149) ~[spring-core-6.1.12.jar!/:6.1.12]
	at org.springframework.web.client.DefaultResponseErrorHandler.getResponseBody(DefaultResponseErrorHandler.java:234) ~[spring-web-6.1.12.jar!/:6.1.12]
	at org.springframework.web.client.DefaultResponseErrorHandler.handleError(DefaultResponseErrorHandler.java:177) ~[spring-web-6.1.12.jar!/:6.1.12]
	at org.springframework.web.client.DefaultResponseErrorHandler.handleError(DefaultResponseErrorHandler.java:137) ~[spring-web-6.1.12.jar!/:6.1.12]
	at org.springframework.web.client.ResponseErrorHandler.handleError(ResponseErrorHandler.java:63) ~[spring-web-6.1.12.jar!/:6.1.12]
	at org.springframework.web.client.RestTemplate.handleResponse(RestTemplate.java:942) ~[spring-web-6.1.12.jar!/:6.1.12]
	at org.springframework.web.client.RestTemplate.doExecute(RestTemplate.java:891) ~[spring-web-6.1.12.jar!/:6.1.12]
	at org.springframework.web.client.RestTemplate.execute(RestTemplate.java:790) ~[spring-web-6.1.12.jar!/:6.1.12]
	at org.springframework.web.client.RestTemplate.postForObject(RestTemplate.java:507) ~[spring-web-6.1.12.jar!/:6.1.12]
	at org.gridsuite.study.server.service.NetworkMapService.getElementsInfos(NetworkMapService.java:76) ~[!/:na]
	at org.gridsuite.study.server.service.StudyService.getNetworkElementsInfos(StudyService.java:789) ~[!/:na]
	
	
