### PR TITLE
fix: remove httpclient5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,6 @@
         <mockwebserver3.version>5.0.0-alpha.14</mockwebserver3.version>
         <!-- TODO network-modification.version remove when migration powsybl -->
         <network-modification.version>0.18.0</network-modification.version>
-        <apache.httpclient.version>5.3</apache.httpclient.version>
         <db-util.version>1.0.5</db-util.version>
         <sonar.organization>gridsuite</sonar.organization>
         <sonar.projectKey>org.gridsuite:study-server</sonar.projectKey>
@@ -104,12 +103,6 @@
             </dependency>
 
             <!-- project specific dependencies -->
-            <dependency>
-                <groupId>org.apache.httpcomponents.client5</groupId>
-                <artifactId>httpclient5</artifactId>
-                <version>${apache.httpclient.version}</version>
-            </dependency>
-
             <dependency>
                 <groupId>com.vladmihalcea</groupId>
                 <artifactId>db-util</artifactId>
@@ -196,12 +189,6 @@
         </dependency>
 
         <!-- Runtime dependencies -->
-        <dependency>
-            <!-- Used by RestTemplate -->
-            <groupId>org.apache.httpcomponents.client5</groupId>
-            <artifactId>httpclient5</artifactId>
-            <scope>runtime</scope>
-        </dependency>
         <dependency>
             <groupId>org.liquibase</groupId>
             <artifactId>liquibase-core</artifactId>

--- a/src/main/java/org/gridsuite/study/server/RestTemplateConfig.java
+++ b/src/main/java/org/gridsuite/study/server/RestTemplateConfig.java
@@ -20,9 +20,9 @@ import com.powsybl.security.json.SecurityAnalysisJsonModule;
 import com.powsybl.sensitivity.json.SensitivityJsonModule;
 import com.powsybl.shortcircuit.json.ShortCircuitAnalysisJsonModule;
 import com.powsybl.timeseries.json.TimeSeriesJsonModule;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
@@ -32,8 +32,8 @@ import org.springframework.web.client.RestTemplate;
 public class RestTemplateConfig {
 
     @Bean
-    public RestTemplate restTemplate() {
-        final RestTemplate restTemplate = new RestTemplate(new HttpComponentsClientHttpRequestFactory());
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        final RestTemplate restTemplate = builder.build();
 
         //find and replace Jackson message converter with our own
         for (int i = 0; i < restTemplate.getMessageConverters().size(); i++) {


### PR DESCRIPTION
All our services use the default version of HTTP client provided by spring-web. Here in study-server we introduced a new HTTP client provided by apache httpclient5. We have to double check with @ayolab if there was an important reason to do so. But to keep it harmonized between our services we prefer to remove it for now. 

We witnessed unwanted side-effect of this client due to a pool of HTTP request that was very limited (only 5 per host, under load this would make all requests take minutes waiting for this pool!) and hard to configure (no spring auto-configuration)