### PR TITLE
Fix reports handling

### DIFF
--- a/src/main/java/org/gridsuite/study/server/dto/BuildInfos.java
+++ b/src/main/java/org/gridsuite/study/server/dto/BuildInfos.java
@@ -32,6 +32,8 @@ public class BuildInfos {
 
     private List<ReportInfos> reportsInfos = new ArrayList<>();
 
+    private Map<UUID, UUID> modificationNodeReports = new HashMap<>();
+
     public void insertModificationInfos(UUID modificationGroupUuid, Set<UUID> modificationUuidsToExclude, ReportInfos reportInfos) {
         if (modificationUuidsToExclude != null && !modificationUuidsToExclude.isEmpty()) {
             this.modificationUuidsToExclude.put(modificationGroupUuid, modificationUuidsToExclude);

--- a/src/main/java/org/gridsuite/study/server/service/NetworkModificationTreeService.java
+++ b/src/main/java/org/gridsuite/study/server/service/NetworkModificationTreeService.java
@@ -789,9 +789,15 @@ public class NetworkModificationTreeService {
             if (!rootNetworkNodeInfoEntity.getNodeBuildStatus().toDto().isBuilt()) {
                 UUID reportUuid = getModificationReportUuid(nodeEntity.getIdNode(), rootNetworkUuid, nodeToBuildUuid);
                 buildInfos.insertModificationInfos(modificationNode.getModificationGroupUuid(), rootNetworkNodeInfoEntity.getModificationsUuidsToExclude(), new ReportInfos(reportUuid, modificationNode.getId()));
+                buildInfos.getModificationNodeReports().put(modificationNode.getId(), reportUuid);
                 getBuildInfos(nodeEntity.getParentNode(), rootNetworkUuid, buildInfos, nodeToBuildUuid);
             } else {
                 buildInfos.setOriginVariantId(self.getVariantId(nodeEntity.getIdNode(), rootNetworkUuid));
+                self.getModificationReports(modificationNode.getId(), rootNetworkUuid)
+                    .forEach((nodeUuid, reportUuid) -> {
+                        UUID duplicatedReportUuid = reportService.duplicateReport(reportUuid);
+                        buildInfos.getModificationNodeReports().put(nodeUuid, duplicatedReportUuid);
+                    });
             }
         }
     }

--- a/src/main/java/org/gridsuite/study/server/service/StudyService.java
+++ b/src/main/java/org/gridsuite/study/server/service/StudyService.java
@@ -1679,8 +1679,7 @@ public class StudyService {
     public void buildNode(@NonNull UUID studyUuid, @NonNull UUID nodeUuid, @NonNull UUID rootNetworkUuid, @NonNull String userId, AbstractWorkflowInfos workflowInfos) {
         assertCanBuildNode(studyUuid, rootNetworkUuid, userId);
         BuildInfos buildInfos = networkModificationTreeService.getBuildInfos(nodeUuid, rootNetworkUuid);
-        Map<UUID, UUID> nodeUuidToReportUuid = buildInfos.getReportsInfos().stream().collect(Collectors.toMap(ReportInfos::nodeUuid, ReportInfos::reportUuid));
-        networkModificationTreeService.setModificationReports(nodeUuid, rootNetworkUuid, nodeUuidToReportUuid);
+        networkModificationTreeService.setModificationReports(nodeUuid, rootNetworkUuid, buildInfos.getModificationNodeReports());
         networkModificationTreeService.updateNodeBuildStatus(nodeUuid, rootNetworkUuid, NodeBuildStatus.from(BuildStatus.BUILDING));
         try {
             networkModificationService.buildNode(nodeUuid, rootNetworkUuid, buildInfos, workflowInfos);

--- a/src/test/java/org/gridsuite/study/server/ModificationIndexationTest.java
+++ b/src/test/java/org/gridsuite/study/server/ModificationIndexationTest.java
@@ -93,7 +93,7 @@ class ModificationIndexationTest {
             node3.getModificationGroupUuid()
         ));
 
-        SQLStatementCountValidator.assertSelectCount(17);
+        SQLStatementCountValidator.assertSelectCount(19);
     }
 
     @Test
@@ -105,7 +105,7 @@ class ModificationIndexationTest {
             node5.getModificationGroupUuid()
         ));
 
-        SQLStatementCountValidator.assertSelectCount(17);
+        SQLStatementCountValidator.assertSelectCount(21);
     }
 
     @Test
@@ -116,7 +116,7 @@ class ModificationIndexationTest {
             node5.getModificationGroupUuid()
         ));
 
-        SQLStatementCountValidator.assertSelectCount(8);
+        SQLStatementCountValidator.assertSelectCount(10);
     }
 
     @Test
@@ -128,7 +128,7 @@ class ModificationIndexationTest {
             node3.getModificationGroupUuid()
         ));
 
-        SQLStatementCountValidator.assertSelectCount(17);
+        SQLStatementCountValidator.assertSelectCount(19);
     }
 
     @Test
@@ -137,7 +137,7 @@ class ModificationIndexationTest {
 
         assertThat(invalidateNodeInfos.getGroupUuids()).isEmpty();
 
-        SQLStatementCountValidator.assertSelectCount(8);
+        SQLStatementCountValidator.assertSelectCount(11);
     }
 
     @Test
@@ -149,7 +149,7 @@ class ModificationIndexationTest {
             node3.getModificationGroupUuid()
         ));
 
-        SQLStatementCountValidator.assertSelectCount(19);
+        SQLStatementCountValidator.assertSelectCount(20);
     }
 
     private void createStudyAndNodesWithIndexedModification() {

--- a/src/test/java/org/gridsuite/study/server/NetworkModificationTest.java
+++ b/src/test/java/org/gridsuite/study/server/NetworkModificationTest.java
@@ -507,7 +507,7 @@ class NetworkModificationTest {
     }
 
     @Test
-    void testBuild() throws Exception {
+    void testBuild(final MockWebServer server) throws Exception {
         String userId = USER_ID;
         StudyEntity studyEntity = insertDummyStudy(UUID.fromString(NETWORK_UUID_STRING), CASE_UUID, "UCTE");
         UUID rootNetworkUuid = studyEntity.getFirstRootNetwork().getId();
@@ -591,6 +591,9 @@ class NetworkModificationTest {
 
         assertEquals(BuildStatus.NOT_BUILT, networkModificationTreeService.getNodeBuildStatus(modificationNode4.getId(), rootNetworkUuid).getGlobalBuildStatus());
         assertEquals(BuildStatus.BUILT, networkModificationTreeService.getNodeBuildStatus(modificationNode5.getId(), rootNetworkUuid).getGlobalBuildStatus());
+
+        Set<RequestWithBody> requests = TestUtils.getRequestsWithBodyDone(2, server);
+        assertTrue(requests.stream().anyMatch(r -> r.getPath().matches("/v1/reports/.*/duplicate")));
     }
 
     @Test

--- a/src/test/java/org/gridsuite/study/server/NetworkModificationTest.java
+++ b/src/test/java/org/gridsuite/study/server/NetworkModificationTest.java
@@ -507,7 +507,7 @@ class NetworkModificationTest {
     }
 
     @Test
-    void testBuild(final MockWebServer server) throws Exception {
+    void testBuild() throws Exception {
         String userId = USER_ID;
         StudyEntity studyEntity = insertDummyStudy(UUID.fromString(NETWORK_UUID_STRING), CASE_UUID, "UCTE");
         UUID rootNetworkUuid = studyEntity.getFirstRootNetwork().getId();
@@ -591,9 +591,6 @@ class NetworkModificationTest {
 
         assertEquals(BuildStatus.NOT_BUILT, networkModificationTreeService.getNodeBuildStatus(modificationNode4.getId(), rootNetworkUuid).getGlobalBuildStatus());
         assertEquals(BuildStatus.BUILT, networkModificationTreeService.getNodeBuildStatus(modificationNode5.getId(), rootNetworkUuid).getGlobalBuildStatus());
-
-        Set<RequestWithBody> requests = TestUtils.getRequestsWithBodyDone(2, server);
-        assertTrue(requests.stream().anyMatch(r -> r.getPath().matches("/v1/reports/.*/duplicate")));
     }
 
     @Test


### PR DESCRIPTION
Check if modification node report is referenced by its children before deleting it
This avoids losing ancestor reports when nodes are unbuilt.