### PR TITLE
get status of DS and DSA, return string not enum like other statuses

### DIFF
--- a/src/main/java/org/gridsuite/study/server/controller/StudyController.java
+++ b/src/main/java/org/gridsuite/study/server/controller/StudyController.java
@@ -1981,11 +1981,11 @@ public class StudyController {
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "The status of dynamic simulation result"),
         @ApiResponse(responseCode = "204", description = "No dynamic simulation status"),
         @ApiResponse(responseCode = "404", description = "The dynamic simulation has not been found")})
-    public ResponseEntity<DynamicSimulationStatus> getDynamicSimulationStatus(@Parameter(description = "study UUID") @PathVariable("studyUuid") UUID studyUuid,
+    public ResponseEntity<String> getDynamicSimulationStatus(@Parameter(description = "study UUID") @PathVariable("studyUuid") UUID studyUuid,
                                                              @Parameter(description = "rootNetworkUuid") @PathVariable("rootNetworkUuid") UUID rootNetworkUuid,
                                                              @Parameter(description = "nodeUuid") @PathVariable("nodeUuid") UUID nodeUuid) {
         DynamicSimulationStatus result = rootNetworkNodeInfoService.getDynamicSimulationStatus(nodeUuid, rootNetworkUuid);
-        return result != null ? ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(result) :
+        return result != null ? ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(result.name()) :
                 ResponseEntity.noContent().build();
     }
 
@@ -2031,11 +2031,11 @@ public class StudyController {
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "The status of dynamic security analysis result"),
         @ApiResponse(responseCode = "204", description = "No dynamic security analysis status"),
         @ApiResponse(responseCode = "404", description = "The dynamic security analysis has not been found")})
-    public ResponseEntity<DynamicSecurityAnalysisStatus> getDynamicSecurityAnalysisStatus(@Parameter(description = "study UUID") @PathVariable("studyUuid") UUID studyUuid,
+    public ResponseEntity<String> getDynamicSecurityAnalysisStatus(@Parameter(description = "study UUID") @PathVariable("studyUuid") UUID studyUuid,
                                                                                           @Parameter(description = "root network id") @PathVariable("rootNetworkUuid") UUID rootNetworkUuid,
                                                                                           @Parameter(description = "nodeUuid") @PathVariable("nodeUuid") UUID nodeUuid) {
         DynamicSecurityAnalysisStatus result = rootNetworkNodeInfoService.getDynamicSecurityAnalysisStatus(nodeUuid, rootNetworkUuid);
-        return result != null ? ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(result) :
+        return result != null ? ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(result.name()) :
                 ResponseEntity.noContent().build();
     }
 

--- a/src/test/java/org/gridsuite/study/server/StudyControllerDynamicSecurityAnalysisTest.java
+++ b/src/test/java/org/gridsuite/study/server/StudyControllerDynamicSecurityAnalysisTest.java
@@ -444,7 +444,7 @@ class StudyControllerDynamicSecurityAnalysisTest {
                         STUDY_UUID, ROOT_NETWORK_UUID, NODE_UUID)
                         .header(HEADER_USER_ID_NAME, HEADER_USER_ID_VALUE))
                 .andExpect(status().isOk()).andReturn();
-        DynamicSecurityAnalysisStatus statusResult = objectMapper.readValue(result.getResponse().getContentAsString(), DynamicSecurityAnalysisStatus.class);
+        DynamicSecurityAnalysisStatus statusResult = DynamicSecurityAnalysisStatus.valueOf(result.getResponse().getContentAsString());
 
         // --- check result --- //
         DynamicSecurityAnalysisStatus statusExpected = DynamicSecurityAnalysisStatus.FAILED;

--- a/src/test/java/org/gridsuite/study/server/StudyControllerDynamicSimulationTest.java
+++ b/src/test/java/org/gridsuite/study/server/StudyControllerDynamicSimulationTest.java
@@ -606,7 +606,7 @@ class StudyControllerDynamicSimulationTest {
                         STUDY_UUID, ROOT_NETWORK_UUID, NODE_UUID)
                         .header(HEADER_USER_ID_NAME, HEADER_USER_ID_VALUE))
                 .andExpect(status().isOk()).andReturn();
-        DynamicSimulationStatus statusResult = objectMapper.readValue(result.getResponse().getContentAsString(), DynamicSimulationStatus.class);
+        DynamicSimulationStatus statusResult = DynamicSimulationStatus.valueOf(result.getResponse().getContentAsString());
 
         // --- check result --- //
         DynamicSimulationStatus statusExpected = DynamicSimulationStatus.DIVERGED;


### PR DESCRIPTION
Related PR front : https://github.com/gridsuite/gridstudy-app/pull/3292
EDIT: This PR was originally done to fix various (sometimes 1s, sometimes 200ms) performance problems but empirically this change doesn't affect performance or only in the order of miliseconds