### PR TITLE
Remove outdated comment about rootNeworks and import parameters

### DIFF
--- a/src/main/java/org/gridsuite/study/server/service/ConsumerService.java
+++ b/src/main/java/org/gridsuite/study/server/service/ConsumerService.java
@@ -213,7 +213,6 @@ public class ConsumerService {
         }
     }
 
-    //TODO: should be linked to a specific rootNetwork
     @Bean
     public Consumer<Message<String>> consumeCaseImportSucceeded() {
         return message -> {


### PR DESCRIPTION
## PR Summary
After [Migrate import params to root nerwork](https://github.com/gridsuite/study-server/commit/e18ebba28ec8dc3623765a4e7847e51ce8a6a93d), import parameters are indeed linked to a root network, no longer to a study. The comment is outdated.



