### PR TITLE
report use uuid, parentOrder as key instead of having an extra v7 ordered uuid

### DIFF
--- a/src/main/java/org/gridsuite/study/server/dto/Report.java
+++ b/src/main/java/org/gridsuite/study/server/dto/Report.java
@@ -20,8 +20,9 @@ import java.util.UUID;
 @Builder
 public record Report(
         UUID id,
-        UUID parentId,
+        Integer parentOrder,
         String message,
         StudyConstants.Severity severity,
+        int order,
         List<Report> subReports
 ) { }

--- a/src/main/java/org/gridsuite/study/server/dto/ReportLog.java
+++ b/src/main/java/org/gridsuite/study/server/dto/ReportLog.java
@@ -8,11 +8,9 @@ package org.gridsuite.study.server.dto;
 
 import org.gridsuite.study.server.StudyConstants;
 
-import java.util.UUID;
-
 /**
  * @author Abdelsalem Hedhili <abdelsalem.hedhili at rte-france.com>
  */
-public record ReportLog(String message, StudyConstants.Severity severity, int depth, UUID parentId) {
+public record ReportLog(String message, StudyConstants.Severity severity, int depth, Integer parentOrder) {
 
 }

--- a/src/test/java/org/gridsuite/study/server/studycontroller/StudyTestBase.java
+++ b/src/test/java/org/gridsuite/study/server/studycontroller/StudyTestBase.java
@@ -116,9 +116,9 @@ class StudyTestBase {
     protected static final NetworkInfos NOT_EXISTING_NETWORK_INFOS = new NetworkInfos(NOT_EXISTING_NETWORK_UUID, "not_existing_network_id");
     protected static final UUID REPORT_UUID = UUID.randomUUID();
     protected static final Report REPORT_TEST = Report.builder().id(REPORT_UUID).message("test").severity(StudyConstants.Severity.WARN).build();
-    protected static final UUID REPORT_LOG_PARENT_UUID = UUID.randomUUID();
+    protected static final int REPORT_LOG_PARENT_ORDER = 0;
     protected static final UUID REPORT_ID = UUID.randomUUID();
-    protected static final List<ReportLog> REPORT_LOGS = List.of(new ReportLog("test", StudyConstants.Severity.WARN, 0, REPORT_LOG_PARENT_UUID));
+    protected static final List<ReportLog> REPORT_LOGS = List.of(new ReportLog("test", StudyConstants.Severity.WARN, 0, REPORT_LOG_PARENT_ORDER));
     protected static final ReportPage REPORT_PAGE = new ReportPage(0, REPORT_LOGS, 1, 1);
     protected static final String VARIANT_ID = "variant_1";
     protected static final String VARIANT_ID_2 = "variant_2";

--- a/src/test/java/org/gridsuite/study/server/utils/MatcherReportLog.java
+++ b/src/test/java/org/gridsuite/study/server/utils/MatcherReportLog.java
@@ -25,7 +25,7 @@ public class MatcherReportLog extends TypeSafeMatcher<ReportLog> {
 
     @Override
     public boolean matchesSafely(ReportLog m) {
-        return Objects.equals(reference.message(), m.message()) && Objects.equals(reference.severity(), m.severity()) && Objects.equals(reference.parentId(), m.parentId());
+        return Objects.equals(reference.message(), m.message()) && Objects.equals(reference.severity(), m.severity()) && Objects.equals(reference.parentOrder(), m.parentOrder());
     }
 
     @Override


### PR DESCRIPTION
"look at report-server/ the diffs from main I changed the PK from uuid to (uuid, order). This changes the API. adapt the code ok now look at study-server it needs updating for parentOrder"

## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->



