### PR TITLE
Fix invalidated multiroot studies blocked nodes

### DIFF
--- a/src/main/java/org/gridsuite/study/server/service/StudyService.java
+++ b/src/main/java/org/gridsuite/study/server/service/StudyService.java
@@ -3703,16 +3703,11 @@ public class StudyService {
     public void invalidateStudyRootNetwork(UUID studyUuid, UUID rootNetworkUuid, String userId) {
         rootNetworkService.assertIsRootNetworkInStudy(studyUuid, rootNetworkUuid);
         var rootNodeUuid = networkModificationTreeService.getStudyRootNodeUuid(studyUuid);
-        try {
-            // First we unbuild all nodes
-            doUnbuildNodeTree(studyUuid, rootNodeUuid, true, true, userId);
-            // Then we erase data linked to root node on all root networks
-            rootNetworkService.invalidateRootNetworkRemoteInfos(List.of(rootNetworkService.getRootNetworkInfos(rootNetworkUuid)), true, false);
-            rootNetworkService.updateRootNetworkIndexationStatus(studyUuid, rootNetworkUuid, RootNetworkIndexationStatus.NOT_INDEXED);
-        } finally {
-            networkModificationTreeService.unblockNodeTree(rootNetworkUuid, rootNodeUuid);
-        }
-
+        // First we unbuild all nodes
+        doUnbuildNodeTree(studyUuid, rootNodeUuid, true, true, userId);
+        // Then we erase data linked to root node on all root networks
+        rootNetworkService.invalidateRootNetworkRemoteInfos(List.of(rootNetworkService.getRootNetworkInfos(rootNetworkUuid)), true, false);
+        rootNetworkService.updateRootNetworkIndexationStatus(studyUuid, rootNetworkUuid, RootNetworkIndexationStatus.NOT_INDEXED);
         notificationService.emitRootNetworksUpdated(studyUuid);
     }
 }

--- a/src/main/java/org/gridsuite/study/server/service/SupervisionService.java
+++ b/src/main/java/org/gridsuite/study/server/service/SupervisionService.java
@@ -373,9 +373,14 @@ public class SupervisionService {
     public void invalidateStudy(UUID studyUuid) {
         AtomicReference<Long> startTime = new AtomicReference<>();
         startTime.set(System.nanoTime());
-        rootNetworkService.getStudyRootNetworkIds(studyUuid).forEach(rnId ->
-                studyService.invalidateStudyRootNetwork(studyUuid, rnId, SUPERVISION_USER)
-        );
+        try {
+            rootNetworkService.getStudyRootNetworkIds(studyUuid).forEach(rnId ->
+                    studyService.invalidateStudyRootNetwork(studyUuid, rnId, SUPERVISION_USER)
+            );
+        } finally {
+            var rootNodeUuid = networkModificationTreeService.getStudyRootNodeUuid(studyUuid);
+            studyService.unblockNodeTree(studyUuid, rootNodeUuid);
+        }
         notificationService.emitElementUpdated(studyUuid, SUPERVISION_USER);
         LOGGER.trace("Study {} nodes builds deleted and root node invalidated in : {} milliseconds", studyUuid, TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime.get()));
     }

--- a/src/test/java/org/gridsuite/study/server/SupervisionControllerTest.java
+++ b/src/test/java/org/gridsuite/study/server/SupervisionControllerTest.java
@@ -170,7 +170,7 @@ class SupervisionControllerTest {
                         .id(rootNetworkUuid)
                         .name("second")
                         .tag("SND")
-                        .caseInfos(new CaseInfos(UUID.randomUUID(), null, "secondCase", "XIIDM"))
+                        .caseInfos(new CaseInfos(SECOND_CASE_UUID, null, "secondCase", "XIIDM"))
                         .networkInfos(new NetworkInfos(networkUuid, "secondNetworkId"))
                         .build(),
                 "userId");
@@ -178,7 +178,7 @@ class SupervisionControllerTest {
                 RootNetworkInfos.builder()
                         .id(rootNetworkUuid)
                         .networkInfos(new NetworkInfos(networkUuid, "secondNetworkId"))
-                        .caseInfos(new CaseInfos(UUID.randomUUID(), null, "secondCase", "XIIDM"))
+                        .caseInfos(new CaseInfos(SECOND_CASE_UUID, null, "secondCase", "XIIDM"))
                         .build());
     }
 

--- a/src/test/java/org/gridsuite/study/server/SupervisionControllerTest.java
+++ b/src/test/java/org/gridsuite/study/server/SupervisionControllerTest.java
@@ -348,14 +348,18 @@ class SupervisionControllerTest {
         mockMvc.perform(delete("/v1/supervision/studies/{studyUuid}/invalidate", STUDY_UUID))
                 .andExpect(status().isOk());
 
+        // Check that both root network underlying networks have been erased
         Mockito.verify(rootNetworkService, Mockito.times(2))
                 .invalidateRootNetworkRemoteInfos(any(), eq(true), eq(false));
         Mockito.verify(networkStoreService, Mockito.times(1)).deleteNetwork(NETWORK_UUID);
         Mockito.verify(networkStoreService, Mockito.times(1)).deleteNetwork(SECOND_NETWORK_UUID);
 
+        // Check that the study index data has been erased
         assertIndexationStatus(STUDY_UUID, RootNetworkIndexationStatus.NOT_INDEXED.name());
         assertIndexationCount(0, 0);
 
+        // Check that all nodes aren't blocked
+        Mockito.verify(studyService, Mockito.times(1)).unblockNodeTree(eq(STUDY_UUID), any());
         List<UUID> allRootNetworkUuids = rootNetworkService.getStudyRootNetworkIds(STUDY_UUID);
         assertThat(allRootNetworkUuids).hasSize(2);
         allRootNetworkUuids.forEach(rootNetworkUuid ->

--- a/src/test/java/org/gridsuite/study/server/SupervisionControllerTest.java
+++ b/src/test/java/org/gridsuite/study/server/SupervisionControllerTest.java
@@ -18,10 +18,7 @@ import com.powsybl.iidm.serde.XMLImporter;
 import com.powsybl.network.store.client.NetworkStoreService;
 import com.powsybl.network.store.iidm.impl.NetworkFactoryImpl;
 import org.elasticsearch.client.RestClient;
-import org.gridsuite.study.server.dto.BasicRootNetworkInfos;
-import org.gridsuite.study.server.dto.CreatedStudyBasicInfos;
-import org.gridsuite.study.server.dto.RootNetworkIndexationStatus;
-import org.gridsuite.study.server.dto.VoltageLevelInfos;
+import org.gridsuite.study.server.dto.*;
 import org.gridsuite.study.server.dto.elasticsearch.EquipmentInfos;
 import org.gridsuite.study.server.dto.elasticsearch.TombstonedEquipmentInfos;
 import org.gridsuite.study.server.dto.supervision.SupervisionStudyInfos;
@@ -29,6 +26,7 @@ import org.gridsuite.study.server.elasticsearch.EquipmentInfosService;
 import org.gridsuite.study.server.elasticsearch.StudyInfosService;
 import org.gridsuite.study.server.repository.StudyEntity;
 import org.gridsuite.study.server.repository.StudyRepository;
+import org.gridsuite.study.server.repository.rootnetwork.RootNetworkNodeInfoRepository;
 import org.gridsuite.study.server.service.*;
 import org.gridsuite.study.server.utils.TestUtils;
 import org.junit.jupiter.api.AfterEach;
@@ -49,6 +47,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -77,6 +76,9 @@ class SupervisionControllerTest {
     private static final UUID CASE_UUID = UUID.randomUUID();
     private static final UUID NETWORK_UUID = UUID.randomUUID();
     private static final UUID STUDY_UUID = UUID.randomUUID();
+
+    private static final UUID SECOND_NETWORK_UUID = UUID.randomUUID();
+    private static final UUID SECOND_CASE_UUID = UUID.randomUUID();
 
     @Autowired
     private NetworkModificationTreeService networkModificationTreeService;
@@ -113,6 +115,9 @@ class SupervisionControllerTest {
 
     @Autowired
     private StudyInfosService studyInfosService;
+
+    @Autowired
+    private RootNetworkNodeInfoRepository rootNetworkNodeInfoRepository;
 
     private static EquipmentInfos toEquipmentInfos(Identifiable<?> i) {
         return EquipmentInfos.builder()
@@ -157,6 +162,24 @@ class SupervisionControllerTest {
         when(rootNetworkService.getNetworkUuid(rootNetworkUuid)).thenReturn(NETWORK_UUID);
         assertIndexationStatus(STUDY_UUID, RootNetworkIndexationStatus.INDEXED.name());
         return study;
+    }
+
+    private void addSecondRootNetwork(UUID rootNetworkUuid, UUID networkUuid) {
+        rootNetworkService.insertCreationRequest(STUDY_UUID,
+                RootNetworkInfos.builder()
+                        .id(rootNetworkUuid)
+                        .name("second")
+                        .tag("SND")
+                        .caseInfos(new CaseInfos(UUID.randomUUID(), null, "secondCase", "XIIDM"))
+                        .networkInfos(new NetworkInfos(networkUuid, "secondNetworkId"))
+                        .build(),
+                "userId");
+        studyService.createRootNetwork(STUDY_UUID,
+                RootNetworkInfos.builder()
+                        .id(rootNetworkUuid)
+                        .networkInfos(new NetworkInfos(networkUuid, "secondNetworkId"))
+                        .caseInfos(new CaseInfos(UUID.randomUUID(), null, "secondCase", "XIIDM"))
+                        .build());
     }
 
     private void assertIndexationCount(long expectedEquipmentsIndexationCount, long expectedTombstonedEquipmentsIndexationCount) throws Exception {
@@ -315,18 +338,28 @@ class SupervisionControllerTest {
     @Test
     void testInvalidateStudy() throws Exception {
         initStudy();
+        UUID secondRootNetworkUuid = UUID.randomUUID();
+        addSecondRootNetwork(secondRootNetworkUuid, SECOND_NETWORK_UUID);
+        when(rootNetworkService.getNetworkUuid(secondRootNetworkUuid)).thenReturn(SECOND_NETWORK_UUID);
+
         Mockito.doNothing().when(networkStoreService).deleteNetwork(NETWORK_UUID);
+        Mockito.doNothing().when(networkStoreService).deleteNetwork(SECOND_NETWORK_UUID);
 
         mockMvc.perform(delete("/v1/supervision/studies/{studyUuid}/invalidate", STUDY_UUID))
                 .andExpect(status().isOk());
 
-        // Remote root-network data was deleted
-        Mockito.verify(rootNetworkService, Mockito.times(1))
+        Mockito.verify(rootNetworkService, Mockito.times(2))
                 .invalidateRootNetworkRemoteInfos(any(), eq(true), eq(false));
         Mockito.verify(networkStoreService, Mockito.times(1)).deleteNetwork(NETWORK_UUID);
+        Mockito.verify(networkStoreService, Mockito.times(1)).deleteNetwork(SECOND_NETWORK_UUID);
 
-        // Indexation flipped to NOT_INDEXED so the auto-detect path will reimport on reopen
         assertIndexationStatus(STUDY_UUID, RootNetworkIndexationStatus.NOT_INDEXED.name());
         assertIndexationCount(0, 0);
+
+        List<UUID> allRootNetworkUuids = rootNetworkService.getStudyRootNetworkIds(STUDY_UUID);
+        assertThat(allRootNetworkUuids).hasSize(2);
+        allRootNetworkUuids.forEach(rootNetworkUuid ->
+                rootNetworkNodeInfoRepository.findAllByRootNetworkId(rootNetworkUuid)
+                        .forEach(info -> assertThat(info.getBlockedNode()).isFalse()));
     }
 }


### PR DESCRIPTION
## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->

Unblock node tree only after all root networks have been invalidated. The previous approach oversaw that doUnbuildNodeTree locks all root networks so after unlocking the first root network it was getting locked again one the second pass


