### PR TITLE
Migrate dangling lines import_parameters

### DIFF
--- a/src/main/resources/db/changelog/changesets/changelog_20260612T125031Z.xml
+++ b/src/main/resources/db/changelog/changesets/changelog_20260612T125031Z.xml
@@ -8,6 +8,8 @@
             SET import_parameters = REPLACE(import_parameters, 'cgmesDanglingLineBoundaryNode', 'cgmesBoundaryLineBoundaryNode')
             WHERE import_parameters_key = 'iidm.import.xml.included.extensions'
         </sql>
+    </changeSet>
+    <changeSet author="homereti" id="1781261978000-1">
         <sql>
             UPDATE import_parameters
             SET import_parameters_key = 'iidm.import.cgmes.disconnect-boundary-line-if-boundary-side-is-disconnected'

--- a/src/main/resources/db/changelog/changesets/changelog_20260612T125031Z.xml
+++ b/src/main/resources/db/changelog/changesets/changelog_20260612T125031Z.xml
@@ -1,0 +1,11 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet author="homereti" id="1781261546000-1">
+        <update tableName="import_parameters">
+            <column name="import_parameters" value="cgmesBoundaryLineBoundaryNode"/>
+            <where>import_parameters='cgmesDanglingLineBoundaryNode'</where>
+        </update>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changesets/changelog_20260612T125031Z.xml
+++ b/src/main/resources/db/changelog/changesets/changelog_20260612T125031Z.xml
@@ -3,9 +3,15 @@
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
     <changeSet author="homereti" id="1781261546000-1">
-        <update tableName="import_parameters">
-            <column name="import_parameters" value="cgmesBoundaryLineBoundaryNode"/>
-            <where>import_parameters='cgmesDanglingLineBoundaryNode'</where>
-        </update>
+        <sql>
+            UPDATE import_parameters
+            SET import_parameters = REPLACE(import_parameters, 'cgmesDanglingLineBoundaryNode', 'cgmesBoundaryLineBoundaryNode')
+            WHERE import_parameters_key = 'iidm.import.xml.included.extensions'
+        </sql>
+        <sql>
+            UPDATE import_parameters
+            SET import_parameters_key = 'iidm.import.cgmes.disconnect-boundary-line-if-boundary-side-is-disconnected'
+            WHERE import_parameters_key = 'iidm.import.cgmes.disconnect-dangling-line-if-boundary-side-is-disconnected'
+        </sql>
     </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changesets/changelog_20260612T125031Z.xml
+++ b/src/main/resources/db/changelog/changesets/changelog_20260612T125031Z.xml
@@ -9,7 +9,7 @@
             WHERE import_parameters_key = 'iidm.import.xml.included.extensions'
         </sql>
     </changeSet>
-    <changeSet author="homereti" id="1781261978000-1">
+    <changeSet author="homereti" id="1781261546000-2">
         <sql>
             UPDATE import_parameters
             SET import_parameters_key = 'iidm.import.cgmes.disconnect-boundary-line-if-boundary-side-is-disconnected'

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -380,3 +380,6 @@ databaseChangeLog:
   - include:
       file: changesets/changelog_20260608T095612Z.xml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/changelog_20260612T125031Z.xml
+      relativeToChangelogFile: true


### PR DESCRIPTION
## PR Summary
After dangling lines renaming to boundary lines (https://github.com/powsybl/powsybl-core/pull/3624), saved imports parameters should be renamed.
This is a gridsuite side solution that forces gridsuite to well manage when import parameters and extensions change.

A more robust solution might be implemented by powsybl to ensure backward compatibility.



