### PR TITLE
fix(ConsumerService): ensure study creation error notification is always emitted on case import failure

### DIFF
--- a/src/main/java/org/gridsuite/study/server/service/ConsumerService.java
+++ b/src/main/java/org/gridsuite/study/server/service/ConsumerService.java
@@ -344,30 +344,36 @@ public class ConsumerService {
         return message -> {
             String receiverString = message.getHeaders().get(HEADER_RECEIVER, String.class);
             String errorMessage = message.getHeaders().get(StudyConstants.HEADER_ERROR_MESSAGE, String.class);
-
             if (receiverString != null) {
-                CaseImportReceiver receiver;
                 try {
-                    receiver = objectMapper.readValue(URLDecoder.decode(receiverString, StandardCharsets.UTF_8),
-                        CaseImportReceiver.class);
-                    UUID studyUuid = receiver.getStudyUuid();
-                    String userId = receiver.getUserId();
-                    UUID rootNetworkUuid = receiver.getRootNetworkUuid();
-
-                    if (receiver.getCaseImportAction() == CaseImportAction.STUDY_CREATION) {
-                        studyService.deleteStudyIfNotCreationInProgress(studyUuid, userId);
-                        notificationService.emitStudyCreationError(studyUuid, userId, errorMessage);
-                    } else {
-                        if (receiver.getCaseImportAction() == CaseImportAction.ROOT_NETWORK_CREATION) {
-                            studyService.deleteRootNetworkRequest(rootNetworkUuid);
-                        }
-                        notificationService.emitRootNetworksUpdateFailed(studyUuid, errorMessage);
-                    }
+                    handleCaseImportFailed(receiverString, errorMessage);
                 } catch (Exception e) {
                     LOGGER.error(e.toString(), e);
                 }
             }
         };
+    }
+
+    private void handleCaseImportFailed(String receiverString, String errorMessage) throws JsonProcessingException {
+        CaseImportReceiver receiver = objectMapper.readValue(URLDecoder.decode(receiverString, StandardCharsets.UTF_8),
+            CaseImportReceiver.class);
+        UUID studyUuid = receiver.getStudyUuid();
+        String userId = receiver.getUserId();
+        UUID rootNetworkUuid = receiver.getRootNetworkUuid();
+
+        if (receiver.getCaseImportAction() == CaseImportAction.STUDY_CREATION) {
+            try {
+                studyService.deleteStudyIfNotCreationInProgress(studyUuid, userId);
+            } catch (Exception e) {
+                LOGGER.warn("Could not delete study during case import failure handling: {}", e.getMessage());
+            }
+            notificationService.emitStudyCreationError(studyUuid, userId, errorMessage);
+        } else {
+            if (receiver.getCaseImportAction() == CaseImportAction.ROOT_NETWORK_CREATION) {
+                studyService.deleteRootNetworkRequest(rootNetworkUuid);
+            }
+            notificationService.emitRootNetworksUpdateFailed(studyUuid, errorMessage);
+        }
     }
 
     /**


### PR DESCRIPTION
   Isolate deleteStudyIfNotCreationInProgress in its own try/catch in
   consumeCaseImportFailed so that emitStudyCreationError is always called
   even if the deletion fails due to a concurrent transaction that already
   cleaned up the StudyCreationRequestEntity.
   
   This was causing a flaky test (testCreateStudyWithErrorDuringCaseImport)
   when running the full test suite because the WireMock stub stubImportNetworkWithServerError
   simulates a situation that does not exist in production:
   
   it returns a 5xx HTTP response AND sends a DLX message simultaneously.
   
   In reality, a synchronous 5xx means the network conversion server
   never processed the request and therefore never publishes on case.import.start,
   so no DLX message would ever be generated.
   
   This artificial combination caused the catch block in
   createStudy and the DLX consumer to race against each other trying to
   delete the same StudyCreationRequestEntity. Depending on thread
   scheduling, the consumer's delete could throw an
   ObjectOptimisticLockingFailureException, which was silently caught at the
   outer level, preventing emitStudyCreationError from being called and
   leaving the test waiting for a message that never arrived.


**Solution was just to  catch an exception but as sonar complains with nested try/catch and complexity the method has been cut in two** 




