### PR TITLE
Ignore the applicabilities in a mono root network study

### DIFF
--- a/src/main/java/org/gridsuite/study/server/repository/rootnetwork/RootNetworkEntity.java
+++ b/src/main/java/org/gridsuite/study/server/repository/rootnetwork/RootNetworkEntity.java
@@ -88,6 +88,10 @@ public class RootNetworkEntity {
     @Column(name = "tag", nullable = false)
     private String tag;
 
+    public String getApplicabilityTag() {
+        return study.isMonoRoot() ? null : tag;
+    }
+
     public void addRootNetworkNodeInfo(RootNetworkNodeInfoEntity rootNetworkNodeInfoEntity) {
         rootNetworkNodeInfoEntity.setRootNetwork(this);
         rootNetworkNodeInfos.add(rootNetworkNodeInfoEntity);

--- a/src/main/java/org/gridsuite/study/server/service/NetworkModificationTreeService.java
+++ b/src/main/java/org/gridsuite/study/server/service/NetworkModificationTreeService.java
@@ -1051,7 +1051,7 @@ public class NetworkModificationTreeService {
                 throw new StudyException(BAD_NODE_TYPE, "The node " + entity.getIdNode() + " is not a modification node");
             } else {
                 buildInfos.setDestinationVariantId(self.getVariantId(nodeUuid, rootNetworkUuid));
-                buildInfos.setRootNetworkTag(rootNetworkService.getRootNetworkTag(rootNetworkUuid));
+                buildInfos.setRootNetworkTag(rootNetworkService.getApplicabilityTag(rootNetworkUuid));
                 getBuildInfos(entity, rootNetworkUuid, buildInfos, nodeUuid);
             }
         }, () -> {

--- a/src/main/java/org/gridsuite/study/server/service/RootNetworkNodeInfoService.java
+++ b/src/main/java/org/gridsuite/study/server/service/RootNetworkNodeInfoService.java
@@ -588,7 +588,7 @@ public class RootNetworkNodeInfoService {
                 rootNetworkUuid).orElseThrow(() -> new StudyException(NOT_FOUND, ROOT_NETWORK_NOT_FOUND));
         String variantId = rootNetworkNodeInfoEntity.getVariantId();
         UUID reportUuid = rootNetworkNodeInfoEntity.getModificationReports().get(nodeUuid);
-        return new ModificationApplicationContext(networkUuid, variantId, reportUuid, nodeUuid, rootNetworkNodeInfoEntity.getRootNetwork().getTag());
+        return new ModificationApplicationContext(networkUuid, variantId, reportUuid, nodeUuid, rootNetworkNodeInfoEntity.getRootNetwork().getApplicabilityTag());
     }
 
     private List<UUID> getReportUuids(RootNetworkNodeInfo rootNetworkNodeInfo) {

--- a/src/main/java/org/gridsuite/study/server/service/RootNetworkService.java
+++ b/src/main/java/org/gridsuite/study/server/service/RootNetworkService.java
@@ -175,6 +175,11 @@ public class RootNetworkService {
         return getRootNetwork(rootNetworkUuid).map(RootNetworkEntity::getTag).orElseThrow(() -> new StudyException(NOT_FOUND, "Root network not found"));
     }
 
+    // Mono-root returns null tag, and the applicability for this tag is then ignored
+    public String getApplicabilityTag(UUID rootNetworkUuid) {
+        return getRootNetwork(rootNetworkUuid).orElseThrow(() -> new StudyException(NOT_FOUND, "Root network not found")).getApplicabilityTag();
+    }
+
     public String getCaseName(UUID rootNetworkUuid) {
         return getRootNetwork(rootNetworkUuid).map(RootNetworkEntity::getCaseName).orElseThrow(() -> new StudyException(NOT_FOUND, "Root network not found"));
     }

--- a/src/main/java/org/gridsuite/study/server/service/StudyService.java
+++ b/src/main/java/org/gridsuite/study/server/service/StudyService.java
@@ -367,13 +367,23 @@ public class StudyService {
             rootNetworkService.createRootNetwork(studyEntity, rootNetworkInfos);
             rootNetworkService.deleteRootNetworkRequest(rootNetworkCreationRequestEntityOpt.get());
             //update study entity to multi root
-            if (studyEntity.getRootNetworks().size() > 1) {
+            if (studyEntity.isMonoRoot()) {
                 studyEntity.setMonoRoot(false);
+                invalidatePreviousRootNetworkNodeTree(studyEntity);
             }
         } else {
             rootNetworkService.deleteRootNetworks(studyEntity, List.of(rootNetworkInfos));
         }
         notificationService.emitRootNetworksUpdated(studyUuid);
+    }
+
+    /**
+     * The nodes built while the study was mono root network ignored the applicabilities, so they have to be built
+     * again now that these are taken into account.
+     */
+    private void invalidatePreviousRootNetworkNodeTree(StudyEntity studyEntity) {
+        UUID rootNodeUuid = networkModificationTreeService.getStudyRootNodeUuid(studyEntity.getId());
+        invalidateNodeTree(studyEntity.getId(), rootNodeUuid, studyEntity.getRootNetworks().getFirst().getId());
     }
 
     private void updateRootNetworkBasicInfos(UUID studyUuid, RootNetworkInfos rootNetworkInfos, boolean updateCase) {

--- a/src/main/java/org/gridsuite/study/server/service/StudyService.java
+++ b/src/main/java/org/gridsuite/study/server/service/StudyService.java
@@ -383,7 +383,7 @@ public class StudyService {
      */
     private void invalidatePreviousRootNetworkNodeTree(StudyEntity studyEntity) {
         UUID rootNodeUuid = networkModificationTreeService.getStudyRootNodeUuid(studyEntity.getId());
-        invalidateNodeTree(studyEntity.getId(), rootNodeUuid, studyEntity.getRootNetworks().getFirst().getId());
+        invalidateNodeTree(studyEntity.getId(), rootNodeUuid, studyEntity.getFirstRootNetwork().getId());
     }
 
     private void updateRootNetworkBasicInfos(UUID studyUuid, RootNetworkInfos rootNetworkInfos, boolean updateCase) {

--- a/src/test/java/org/gridsuite/study/server/rootnetworks/RootNetworkApplicabilityTest.java
+++ b/src/test/java/org/gridsuite/study/server/rootnetworks/RootNetworkApplicabilityTest.java
@@ -12,8 +12,10 @@ import org.gridsuite.study.server.ContextConfigurationWithTestChannel;
 import org.gridsuite.study.server.dto.*;
 import org.gridsuite.study.server.dto.networkexport.PermissionType;
 import org.gridsuite.study.server.elasticsearch.EquipmentInfosService;
+import org.gridsuite.study.server.networkmodificationtree.dto.BuildStatus;
 import org.gridsuite.study.server.networkmodificationtree.dto.InsertMode;
 import org.gridsuite.study.server.networkmodificationtree.dto.NetworkModificationNode;
+import org.gridsuite.study.server.networkmodificationtree.dto.NodeBuildStatus;
 import org.gridsuite.study.server.networkmodificationtree.entities.NodeEntity;
 import org.gridsuite.study.server.repository.StudyEntity;
 import org.gridsuite.study.server.repository.StudyRepository;
@@ -39,7 +41,10 @@ import java.util.*;
 
 import static org.gridsuite.study.server.utils.TestUtils.createModificationNodeInfo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -85,6 +90,8 @@ class RootNetworkApplicabilityTest {
     private StudyService studyService;
     @Autowired
     private RootNetworkNodeInfoService rootNetworkNodeInfoService;
+    @Autowired
+    private RootNetworkService rootNetworkService;
     @Autowired
     private MockMvc mockMvc;
     @Autowired
@@ -176,6 +183,7 @@ class RootNetworkApplicabilityTest {
     @Test
     void testBuildInfosCarryRootNetworkTag() {
         StudyEntity studyEntity = TestUtils.createDummyStudy(NETWORK_UUID, CASE_UUID, CASE_NAME, CASE_FORMAT, REPORT_UUID);
+        studyEntity.setMonoRoot(false);
         studyRepository.save(studyEntity);
         UUID rootNetworkUuid = studyService.getExistingBasicRootNetworkInfos(studyEntity.getId()).getFirst().rootNetworkUuid();
 
@@ -194,6 +202,7 @@ class RootNetworkApplicabilityTest {
     @Test
     void testApplicationContextCarriesRootNetworkTag() {
         StudyEntity studyEntity = TestUtils.createDummyStudy(NETWORK_UUID, CASE_UUID, CASE_NAME, CASE_FORMAT, REPORT_UUID);
+        studyEntity.setMonoRoot(false);
         studyRepository.save(studyEntity);
         RootNetworkEntity rootNetworkEntity = studyEntity.getRootNetworks().getFirst();
 
@@ -201,6 +210,52 @@ class RootNetworkApplicabilityTest {
         NetworkModificationNode firstNode = networkModificationTreeService.createNode(studyEntity, rootNode.getIdNode(), createModificationNodeInfo(NODE_1_NAME), InsertMode.AFTER, null);
 
         assertEquals(ROOT_NETWORK_TAG_1, rootNetworkNodeInfoService.getNetworkModificationApplicationContext(rootNetworkEntity.getId(), firstNode.getId(), NETWORK_UUID).rootNetworkTag());
+    }
+
+    @Test
+    void testMonoRootStudyCarriesNoRootNetworkTag() {
+        StudyEntity studyEntity = TestUtils.createDummyStudy(NETWORK_UUID, CASE_UUID, CASE_NAME, CASE_FORMAT, REPORT_UUID);
+        studyEntity.setMonoRoot(true);
+        studyRepository.save(studyEntity);
+        RootNetworkEntity rootNetworkEntity = studyEntity.getRootNetworks().getFirst();
+
+        NodeEntity rootNode = networkModificationTreeService.createRoot(studyEntity);
+        NetworkModificationNode firstNode = networkModificationTreeService.createNode(studyEntity, rootNode.getIdNode(), createModificationNodeInfo(NODE_1_NAME), InsertMode.AFTER, null);
+
+        networkModificationTreeService.buildNode(studyEntity.getId(), firstNode.getId(), rootNetworkEntity.getId(), USER_ID, null);
+
+        ArgumentCaptor<BuildInfos> buildInfosCaptor = ArgumentCaptor.captor();
+        verify(networkModificationService).buildNode(any(UUID.class), any(UUID.class), buildInfosCaptor.capture(), isNull());
+        assertNull(buildInfosCaptor.getValue().getRootNetworkTag());
+        assertNull(rootNetworkNodeInfoService.getNetworkModificationApplicationContext(rootNetworkEntity.getId(), firstNode.getId(), NETWORK_UUID).rootNetworkTag());
+    }
+
+    @Test
+    void testTurningMultiRootNetworkInvalidatesWhatWasBuiltBefore() {
+        StudyEntity studyEntity = TestUtils.createDummyStudy(NETWORK_UUID, CASE_UUID, CASE_NAME, CASE_FORMAT, REPORT_UUID);
+        studyEntity.setMonoRoot(true);
+        studyRepository.save(studyEntity);
+        UUID rootNetworkUuid = studyEntity.getRootNetworks().getFirst().getId();
+
+        NodeEntity rootNode = networkModificationTreeService.createRoot(studyEntity);
+        NetworkModificationNode firstNode = networkModificationTreeService.createNode(studyEntity, rootNode.getIdNode(), createModificationNodeInfo(NODE_1_NAME), InsertMode.AFTER, null);
+        networkModificationTreeService.updateNodeBuildStatus(firstNode.getId(), rootNetworkUuid, NodeBuildStatus.from(BuildStatus.BUILT));
+        assertTrue(networkModificationTreeService.getNodeBuildStatus(firstNode.getId(), rootNetworkUuid).isBuilt());
+
+        RootNetworkInfos secondRootNetworkInfos = RootNetworkInfos.builder()
+            .id(UUID.randomUUID())
+            .name("secondRootNetworkName")
+            .caseInfos(new CaseInfos(UUID.randomUUID(), UUID.randomUUID(), CASE_NAME, CASE_FORMAT))
+            .networkInfos(new NetworkInfos(UUID.randomUUID(), UUID.randomUUID().toString()))
+            .reportUuid(UUID.randomUUID())
+            .tag(ROOT_NETWORK_TAG_2)
+            .build();
+        rootNetworkService.insertCreationRequest(studyEntity.getId(), secondRootNetworkInfos, USER_ID);
+        studyService.createRootNetwork(studyEntity.getId(), secondRootNetworkInfos);
+
+        // the node was built while the applicabilities were ignored, it has to be built again now they are not
+        assertFalse(studyRepository.findById(studyEntity.getId()).orElseThrow().isMonoRoot());
+        assertFalse(networkModificationTreeService.getNodeBuildStatus(firstNode.getId(), rootNetworkUuid).isBuilt());
     }
 
     @Test


### PR DESCRIPTION
A study holding a single root network now resolves no tag at all: every activated modification applies, whatever the applicabilities it carries. Those are left untouched, hidden until the study turns multi root network.

Creating a second root network then invalidates what was built on the first one, since the applicabilities are taken into account from that point on.
