### PR TITLE
Migrate iidm-excluded-extensions

### DIFF
--- a/src/main/resources/db/changelog/changesets/changelog_20260910T140041Z.xml
+++ b/src/main/resources/db/changelog/changesets/changelog_20260910T140041Z.xml
@@ -1,0 +1,12 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet author="homereti" id="178904445100-1">
+        <sql>
+            UPDATE import_parameters
+            SET import_parameters = 'null'
+            WHERE import_parameters_key = 'iidm.die.excluded-extensions' and import_parameters = '[]'
+        </sql>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -395,3 +395,6 @@ databaseChangeLog:
   - include:
       file: changesets/changelog_20260818T152042Z.xml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/changelog_20260910T140041Z.xml
+      relativeToChangelogFile: true


### PR DESCRIPTION
## PR Summary
To be able to reload UNLOADED studies, "[]" values for excluded-extensions should be migrated to "null" values



