### PR TITLE
Fix StudyService.duplicateStudyEntity should keep `monoRoot` property.

### DIFF
--- a/src/main/java/org/gridsuite/study/server/service/StudyService.java
+++ b/src/main/java/org/gridsuite/study/server/service/StudyService.java
@@ -762,6 +762,7 @@ public class StudyService {
             .networkVisualizationParametersUuid(copiedNetworkVisualizationParametersUuid)
             .spreadsheetConfigCollectionUuid(copiedSpreadsheetConfigCollectionUuid)
             .workspacesConfigUuid(copiedWorkspacesConfigUuid)
+            .monoRoot(sourceStudyEntity.isMonoRoot())
             .build());
     }
 

--- a/src/test/java/org/gridsuite/study/server/studycontroller/StudyTest.java
+++ b/src/test/java/org/gridsuite/study/server/studycontroller/StudyTest.java
@@ -1011,6 +1011,8 @@ class StudyTest extends StudyTestBase {
         // duplicate the study
         StudyEntity duplicatedStudy = duplicateStudy(study1Uuid, userId);
         assertNotEquals(study1Uuid, duplicatedStudy.getId());
+        StudyEntity originalStudy = studyRepository.findById(study1Uuid).orElseThrow();
+        assertEquals(originalStudy.isMonoRoot(), duplicatedStudy.isMonoRoot());
 
         // Verify node aliases on the duplicated study
         aliases = mapper.readValue(mockMvc.perform(get("/v1/studies/{studyUuid}/node-aliases", duplicatedStudy.getId())).andExpect(status().isOk()).andReturn()


### PR DESCRIPTION
<!-- DO NOT FORGET TO UPDATE README.MD OR OTHER DOCUMENTATION IF NEEDED-->

## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->
Before: When duplicating a `monoRoot=true` study, the duplicated study loose the value of this property
Now: it is conserved when duplicating a study.

default value of a primitive `boolean` is `false`.



